### PR TITLE
yumPackages: workaround yum failures

### DIFF
--- a/cmd/pke/app/phases/runtime/kubernetes/kubernetes_linux.go
+++ b/cmd/pke/app/phases/runtime/kubernetes/kubernetes_linux.go
@@ -140,6 +140,7 @@ func yumPackages(kubernetesVersion string) []string {
 		"kubelet-" + kubernetesVersion + "-0",
 		"kubeadm-" + kubernetesVersion + "-0",
 		"kubectl-" + kubernetesVersion + "-0",
+		"kubernetes-cni-0.6.0", // FIXME: workaround yum failures
 		"--disableexcludes=kubernetes",
 	}
 }


### PR DESCRIPTION
```
Error: Package: kubelet-1.12.2-0.x86_64 (kubernetes)
Requires: kubernetes-cni = 0.6.0
Available: kubernetes-cni-0.3.0.1-0.07a8a2.x86_64 (kubernetes)
kubernetes-cni = 0.3.0.1-0.07a8a2
Available: kubernetes-cni-0.5.1-0.x86_64 (kubernetes)
kubernetes-cni = 0.5.1-0
Available: kubernetes-cni-0.5.1-1.x86_64 (kubernetes)
kubernetes-cni = 0.5.1-1
Available: kubernetes-cni-0.6.0-0.x86_64 (kubernetes)
kubernetes-cni = 0.6.0-0
Installing: kubernetes-cni-0.7.5-0.x86_64 (kubernetes)
kubernetes-cni = 0.7.5-0
/bin/yum [install -y kubelet-1.12.2-0 kubeadm-1.12.2-0 kubectl-1.12.2-0 --disableexcludes=kubernetes] err: exit status 1 4.933743392s
Error: unable to install packages: exit status 1
```