### PR TITLE
do not limit HTTP retries

### DIFF
--- a/cmd/pke/app/util/transport/retry.go
+++ b/cmd/pke/app/util/transport/retry.go
@@ -29,25 +29,21 @@ func NewRetryTransport(rt http.RoundTripper) *rehttp.Transport {
 		rt,
 		rehttp.RetryAny(
 			rehttp.RetryAll(
-				rehttp.RetryMaxRetries(5),
 				rehttp.RetryHTTPMethods(http.MethodGet),
 				rehttp.RetryStatusInterval(400, 600),
 			),
 			rehttp.RetryAll(
-				rehttp.RetryMaxRetries(5),
 				rehttp.RetryHTTPMethods(http.MethodPost),
 				rehttp.RetryStatusInterval(500, 600),
 			),
 			rehttp.RetryAll(
-				rehttp.RetryMaxRetries(10),
 				rehttp.RetryTemporaryErr(),
 			),
 			rehttp.RetryAll(
-				rehttp.RetryMaxRetries(10),
 				RetryConnectionRefusedErr(),
 			),
 		),
-		rehttp.ExpJitterDelay(2*time.Second, 30*time.Second),
+		rehttp.ExpJitterDelay(2*time.Second, 60*time.Second),
 	)
 }
 


### PR DESCRIPTION
as the tool runs typically on boot, we should not limit the number of
times we poll for conditions to meet our expectations.