### PR TITLE
circleci: invalidate cdn cache after release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  aws: circleci/aws-cli@0.1.13
 
 jobs:
     build:
@@ -117,6 +120,21 @@ jobs:
                     name: Release
                     command: make release
 
+    cdn-invalidate:
+        executor: aws/default
+        steps:
+            -
+                aws/install
+            -
+                aws/configure
+            -
+                run:
+                    name: Invalidate cloudfront edge cache
+                    command: |
+                     aws cloudfront create-invalidation \
+                       --distribution-id ${CDN_DISTRIBUTION_ID} \
+                       --paths "/downloads/pke/*"
+
 workflows:
     version: 2
     build:
@@ -130,6 +148,15 @@ workflows:
                 release:
                     requires:
                         - build
+                    filters:
+                        tags:
+                            only: /^v?\d+\.\d+\.\d+(-\S*)?$/
+                        branches:
+                            ignore: /.*/
+            -
+                cdn-invalidate:
+                    requires:
+                        - release
                     filters:
                         tags:
                             only: /^v?\d+\.\d+\.\d+(-\S*)?$/


### PR DESCRIPTION
Intends to force update banzaicloud.com/downloads/pke/pke-latest.