### PR TITLE
External cloud provider support

### DIFF
--- a/cmd/pke/app/constants/constants.go
+++ b/cmd/pke/app/constants/constants.go
@@ -80,6 +80,15 @@ const (
 	// FlagCloudProvider cloud provider for kubeadm.
 	FlagCloudProvider = "kubernetes-cloud-provider"
 
+	// CloudProviderAmazon Amazon Web Services
+	CloudProviderAmazon = "aws"
+	// CloudProviderAzure Azure Cloud Services
+	CloudProviderAzure = "azure"
+	// CloudProviderVsphere VMware vSphere platform
+	CloudProviderVsphere = "vsphere"
+	// CloudProviderExternal External cloud provider
+	CloudProviderExternal = "external"
+
 	// FlagClusterName cluster name
 	FlagClusterName = "kubernetes-cluster-name"
 
@@ -94,13 +103,6 @@ const (
 	FlagControlPlaneJoin = "kubernetes-join-control-plane"
 	// FlagAdditionalControlPlane upgrade additional control plane node.
 	FlagAdditionalControlPlane = "kubernetes-additional-control-plane"
-
-	// CloudProviderAmazon Amazon Web Services
-	CloudProviderAmazon = "aws"
-	// CloudProviderAzure Azure Cloud Services
-	CloudProviderAzure = "azure"
-	// CloudProviderVsphere VMware vSphere platform
-	CloudProviderVsphere = "vsphere"
 
 	// FlagImageRepository prefix for image repository.
 	FlagImageRepository = "image-repository"

--- a/cmd/pke/app/constants/constants.go
+++ b/cmd/pke/app/constants/constants.go
@@ -165,6 +165,9 @@ const (
 	// FlagTaints specifies the taints the Node should be registered with.
 	FlagTaints = "taints"
 
+	// FlagLabels specifies the labels the Node should be registered with.
+	FlagLabels = "kubernetes-node-labels"
+
 	// Etcd specific flags
 	// FlagExternalEtcdEndpoints endpoints of etcd members.
 	FlagExternalEtcdEndpoints = "etcd-endpoints"

--- a/cmd/pke/app/phases/kubeadm/common.go
+++ b/cmd/pke/app/phases/kubeadm/common.go
@@ -18,17 +18,16 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path/filepath"
 	"text/template"
 	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/pkg/errors"
 )
 
@@ -40,98 +39,92 @@ const (
 //go:generate templify -t ${GOTMPL} -p kubeadm -f kubeadmAzureConfig kubeadm_azure_config.json.tmpl
 
 func WriteKubeadmAzureConfig(out io.Writer, filename, cloudProvider, tenantID, subnetName, securityGroupName, vnetName, vnetResourceGroup, vmType, loadBalancerSku, routeTableName string, excludeMasterFromStandardLB bool) error {
-	if cloudProvider == constants.CloudProviderAzure {
-		if http.DefaultClient.Timeout < 10*time.Second {
-			http.DefaultClient.Timeout = 10 * time.Second
-		}
-
-		req, err := http.NewRequest(http.MethodGet, urlAzureAZ, nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Metadata", "true")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return errors.Errorf("failed to get azure availability zone. http status code: %d", resp.StatusCode)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "failed to read response body")
-		}
-
-		type metadata struct {
-			Compute struct {
-				AZEnvironment     string `json:"azEnvironment"`
-				Location          string `json:"location"`
-				ResourceGroupName string `json:"resourceGroupName"`
-				SubscriptionId    string `json:"subscriptionId"`
-			} `json:"compute"`
-		}
-		var r metadata
-		if err := json.Unmarshal(b, &r); err != nil {
-			return errors.Wrap(err, "failed to parse response")
-		}
-
-		if vmType == "" {
-			vmType = "standard"
-		}
-		if loadBalancerSku == "" {
-			loadBalancerSku = "basic"
-		}
-
-		tmpl, err := template.New("azure-config").Parse(kubeadmAzureConfigTemplate())
-		if err != nil {
-			return err
-		}
-
-		w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = w.Close() }()
-
-		type data struct {
-			Cloud                       string
-			TenantId                    string
-			SubscriptionId              string
-			ResourceGroup               string
-			Location                    string
-			SubnetName                  string
-			SecurityGroupName           string
-			VNetName                    string
-			VNetResourceGroup           string
-			VMType                      string
-			LoadBalancerSku             string
-			RouteTableName              string
-			ExcludeMasterFromStandardLB bool
-		}
-
-		d := data{
-			Cloud:                       r.Compute.AZEnvironment,
-			TenantId:                    tenantID,
-			SubscriptionId:              r.Compute.SubscriptionId,
-			ResourceGroup:               r.Compute.ResourceGroupName,
-			Location:                    r.Compute.Location,
-			SubnetName:                  subnetName,
-			SecurityGroupName:           securityGroupName,
-			VNetName:                    vnetName,
-			VNetResourceGroup:           vnetResourceGroup,
-			VMType:                      vmType,
-			LoadBalancerSku:             loadBalancerSku,
-			RouteTableName:              routeTableName,
-			ExcludeMasterFromStandardLB: excludeMasterFromStandardLB,
-		}
-
-		return tmpl.Execute(w, d)
+	if cloudProvider != constants.CloudProviderAzure {
+		return nil
 	}
 
-	return nil
+	if http.DefaultClient.Timeout < 10*time.Second {
+		http.DefaultClient.Timeout = 10 * time.Second
+	}
+
+	req, err := http.NewRequest(http.MethodGet, urlAzureAZ, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Metadata", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("failed to get azure availability zone. http status code: %d", resp.StatusCode)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
+
+	type metadata struct {
+		Compute struct {
+			AZEnvironment     string `json:"azEnvironment"`
+			Location          string `json:"location"`
+			ResourceGroupName string `json:"resourceGroupName"`
+			SubscriptionId    string `json:"subscriptionId"`
+		} `json:"compute"`
+	}
+	var r metadata
+	if err := json.Unmarshal(b, &r); err != nil {
+		return errors.Wrap(err, "failed to parse response")
+	}
+
+	if vmType == "" {
+		vmType = "standard"
+	}
+	if loadBalancerSku == "" {
+		loadBalancerSku = "basic"
+	}
+
+	tmpl, err := template.New("azure-config").Parse(kubeadmAzureConfigTemplate())
+	if err != nil {
+		return err
+	}
+
+	type data struct {
+		Cloud                       string
+		TenantId                    string
+		SubscriptionId              string
+		ResourceGroup               string
+		Location                    string
+		SubnetName                  string
+		SecurityGroupName           string
+		VNetName                    string
+		VNetResourceGroup           string
+		VMType                      string
+		LoadBalancerSku             string
+		RouteTableName              string
+		ExcludeMasterFromStandardLB bool
+	}
+
+	d := data{
+		Cloud:                       r.Compute.AZEnvironment,
+		TenantId:                    tenantID,
+		SubscriptionId:              r.Compute.SubscriptionId,
+		ResourceGroup:               r.Compute.ResourceGroupName,
+		Location:                    r.Compute.Location,
+		SubnetName:                  subnetName,
+		SecurityGroupName:           securityGroupName,
+		VNetName:                    vnetName,
+		VNetResourceGroup:           vnetResourceGroup,
+		VMType:                      vmType,
+		LoadBalancerSku:             loadBalancerSku,
+		RouteTableName:              routeTableName,
+		ExcludeMasterFromStandardLB: excludeMasterFromStandardLB,
+	}
+
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p kubeadm -f kubeadmVsphereConfig kubeadm_vsphere_config.toml.tmpl
@@ -145,20 +138,6 @@ func WriteKubeadmVsphereConfig(out io.Writer, filename, cloudProvider, server st
 	if err != nil {
 		return err
 	}
-
-	dir := filepath.Dir(filename)
-	_, _ = fmt.Fprintf(out, "creating directory: %q\n", dir)
-	err = os.MkdirAll(dir, 0750)
-	if err != nil {
-		return err
-	}
-
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
 
 	type data struct {
 		Server       string
@@ -184,7 +163,7 @@ func WriteKubeadmVsphereConfig(out io.Writer, filename, cloudProvider, server st
 		Password:     password,
 	}
 
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p kubeadm -f encryptionProvider encryption_provider.yaml.tmpl
@@ -195,7 +174,6 @@ func WriteKubeadmVsphereConfig(out io.Writer, filename, cloudProvider, server st
 // Provided secret will always overwrite existing configuration.
 // Pipeline sourced encryption secret uses this behaviour.
 func WriteEncryptionProviderConfig(out io.Writer, filename, kubernetesVersion, encryptionSecret string) error {
-
 	if encryptionSecret == "" {
 		// check existing configuration
 		if _, err := os.Stat(filename); err == nil {
@@ -230,20 +208,6 @@ func WriteEncryptionProviderConfig(out io.Writer, filename, kubernetesVersion, e
 		return err
 	}
 
-	dir := filepath.Dir(filename)
-	_, _ = fmt.Fprintf(out, "creating directory: %q\n", dir)
-	err = os.MkdirAll(dir, 0750)
-	if err != nil {
-		return err
-	}
-
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
-
 	type data struct {
 		Kind             string
 		APIVersion       string
@@ -256,5 +220,5 @@ func WriteEncryptionProviderConfig(out io.Writer, filename, kubernetesVersion, e
 		EncryptionSecret: encryptionSecret,
 	}
 
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }

--- a/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
@@ -895,61 +895,53 @@ func installWeave(out io.Writer, cloudProvider, podNetworkCIDR, kubeConfig strin
 }
 
 func writeKubeadmAmazonConfig(out io.Writer, filename, cloudProvider string) error {
-	if cloudProvider == constants.CloudProviderAmazon {
-		if http.DefaultClient.Timeout < 10*time.Second {
-			http.DefaultClient.Timeout = 10 * time.Second
-		}
+	if cloudProvider != constants.CloudProviderAmazon {
+		return nil
+	}
 
-		// printf "[GLOBAL]\nZone="$(curl -q -s http://169.254.169.254/latest/meta-data/placement/availability-zone) > /etc/kubernetes/aws.conf
-		resp, err := http.Get(urlAWSAZ)
-		if err != nil {
-			return err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return errors.Errorf("failed to get aws availability zone. http status code: %d", resp.StatusCode)
-		}
-		defer func() { _ = resp.Body.Close() }()
+	if http.DefaultClient.Timeout < 10*time.Second {
+		http.DefaultClient.Timeout = 10 * time.Second
+	}
 
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "failed to read response body")
-		}
+	// printf "[GLOBAL]\nZone="$(curl -q -s http://169.254.169.254/latest/meta-data/placement/availability-zone) > /etc/kubernetes/aws.conf
+	resp, err := http.Get(urlAWSAZ)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("failed to get aws availability zone. http status code: %d", resp.StatusCode)
+	}
+	defer func() { _ = resp.Body.Close() }()
 
-		w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = w.Close() }()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
 
-		_, err = fmt.Fprintf(w, "[GLOBAL]\nZone=%s\n", b)
+	tmpl, err := template.New("amazon").Parse(`[GLOBAL]
+Zone={{ .Zone }}`)
+	if err != nil {
 		return err
 	}
 
-	return nil
+	type data struct {
+		Zone string
+	}
+
+	d := data{
+		Zone: string(b),
+	}
+
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p controlplane -f admissionConfiguration admission_configuration.yaml.tmpl
 
 func writeAdmissionConfiguration(out io.Writer, filename, rateLimitConfigFile string) error {
-	dir := filepath.Dir(filename)
-
-	_, _ = fmt.Fprintf(out, "[%s] creating directory: %q\n", use, dir)
-	err := os.MkdirAll(dir, 0750)
-	if err != nil {
-		return err
-	}
-
 	tmpl, err := template.New("admission-config").Parse(admissionConfigurationTemplate())
 	if err != nil {
 		return err
 	}
-
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
 
 	type data struct {
 		RateLimitConfigFile string
@@ -959,7 +951,7 @@ func writeAdmissionConfiguration(out io.Writer, filename, rateLimitConfigFile st
 		RateLimitConfigFile: rateLimitConfigFile,
 	}
 
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p controlplane -f kubeProxyConfig kube_proxy_config.yaml.tmpl

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -106,6 +107,12 @@ func (c ControlPlane) WriteKubeadmConfig(out io.Writer, filename string) error {
 		kubeReservedMemory = kubeadm.KubeReservedMemory(memory.TotalMemory())
 	)
 
+	// Node labels
+	nodeLabels := c.labels
+	if c.nodepool != "" {
+		nodeLabels = append(nodeLabels, "nodepool.banzaicloud.io/name="+c.nodepool)
+	}
+
 	type data struct {
 		APIServerAdvertiseAddress   string
 		APIServerBindPort           string
@@ -120,7 +127,7 @@ func (c ControlPlane) WriteKubeadmConfig(out io.Writer, filename string) error {
 		CloudProvider               string
 		CloudConfig                 bool
 		KubeletCloudConfig          bool
-		Nodepool                    string
+		NodeLabels                  string
 		ControllerManagerSigningCA  string
 		OIDCIssuerURL               string
 		OIDCClientID                string
@@ -154,7 +161,7 @@ func (c ControlPlane) WriteKubeadmConfig(out io.Writer, filename string) error {
 		CloudProvider:               c.cloudProvider,
 		CloudConfig:                 cloudConfig,
 		KubeletCloudConfig:          kubeletCloudConfig,
-		Nodepool:                    c.nodepool,
+		NodeLabels:                  strings.Join(nodeLabels, ","),
 		ControllerManagerSigningCA:  c.controllerManagerSigningCA,
 		OIDCIssuerURL:               c.oidcIssuerURL,
 		OIDCClientID:                c.oidcClientID,

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
@@ -35,14 +35,6 @@ import (
 //go:generate templify -t ${GOTMPL} -p controlplane -f kubeadmConfigV1Beta1 kubeadm_v1beta1.yaml.tmpl
 
 func (c ControlPlane) WriteKubeadmConfig(out io.Writer, filename string) error {
-	dir := filepath.Dir(filename)
-
-	_, _ = fmt.Fprintf(out, "[%s] creating directory: %q\n", use, dir)
-	err := os.MkdirAll(dir, 0750)
-	if err != nil {
-		return err
-	}
-
 	// API server advertisement
 	bindPort := "6443"
 	if c.advertiseAddress != "" {
@@ -182,14 +174,7 @@ func (c ControlPlane) WriteKubeadmConfig(out io.Writer, filename string) error {
 		KubeReservedMemory:          kubeReservedMemory,
 	}
 
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
-
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p controlplane -f auditV1Beta1 audit_v1beta1.yaml.tmpl

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
@@ -29,8 +29,7 @@ func kubeadmConfigV1Alpha3Template() string {
 		"      value: \"{{.Value}}\"\n" +
 		"      effect: \"{{.Effect}}\"{{end}}\n" +
 		"  kubeletExtraArgs:\n" +
-		"    {{ if .Nodepool }}\n" +
-		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
+		"    {{ if .NodeLabels }}node-labels: \"{{ .NodeLabels }}\"{{end}}\n" +
 		"    # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker\n" +
 		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
 		"    {{ if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}{{end}}\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
@@ -32,9 +32,8 @@ func kubeadmConfigV1Alpha3Template() string {
 		"    {{ if .Nodepool }}\n" +
 		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
 		"    # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker\n" +
-		"    {{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
-		"    {{if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
+		"    {{ if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}{{end}}\n" +
 		"    read-only-port: \"0\"\n" +
 		"    anonymous-auth: \"false\"\n" +
 		"    streaming-connection-idle-timeout: \"5m\"\n" +
@@ -87,7 +86,7 @@ func kubeadmConfigV1Alpha3Template() string {
 		"  oidc-groups-claim: \"groups\"{{end}}\n" +
 		"  {{ if .CloudProvider }}\n" +
 		"  cloud-provider: \"{{ .CloudProvider }}\"\n" +
-		"  cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
+		"  {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
 		"schedulerExtraArgs:\n" +
 		"  profiling: \"false\"\n" +
 		"apiServerExtraVolumes:\n" +
@@ -111,7 +110,7 @@ func kubeadmConfigV1Alpha3Template() string {
 		"    mountPath: /etc/kubernetes/admission-control/\n" +
 		"    writable: false\n" +
 		"    pathType: Directory\n" +
-		"  {{ if .CloudProvider }}\n" +
+		"  {{ if and .CloudProvider .CloudConfig }}\n" +
 		"  - name: cloud-config\n" +
 		"    hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
 		"    mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
@@ -123,11 +122,11 @@ func kubeadmConfigV1Alpha3Template() string {
 		"  {{ if .ControllerManagerSigningCA }}cluster-signing-cert-file: {{ .ControllerManagerSigningCA }}{{end}}\n" +
 		"  {{ if .CloudProvider }}\n" +
 		"  cloud-provider: \"{{ .CloudProvider }}\"\n" +
-		"  cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
+		"  {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
 		"controllerManagerExtraVolumes:\n" +
 		"  - name: cloud-config\n" +
 		"    hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
-		"    mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
+		"    mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}\n" +
 		"etcd:\n" +
 		"  {{ if .EtcdEndpoints }}\n" +
 		"  external:\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.tmpl
@@ -11,8 +11,7 @@ nodeRegistration:
       value: "{{.Value}}"
       effect: "{{.Effect}}"{{end}}
   kubeletExtraArgs:
-    {{ if .Nodepool }}
-    node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
+    {{ if .NodeLabels }}node-labels: "{{ .NodeLabels }}"{{end}}
     # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker
     {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
     {{ if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}{{end}}

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.tmpl
@@ -14,9 +14,8 @@ nodeRegistration:
     {{ if .Nodepool }}
     node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
     # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker
-    {{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"{{end}}
-    {{if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
+    {{ if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}{{end}}
     read-only-port: "0"
     anonymous-auth: "false"
     streaming-connection-idle-timeout: "5m"
@@ -69,7 +68,7 @@ apiServerExtraArgs:
   oidc-groups-claim: "groups"{{end}}
   {{ if .CloudProvider }}
   cloud-provider: "{{ .CloudProvider }}"
-  cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
+  {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
 schedulerExtraArgs:
   profiling: "false"
 apiServerExtraVolumes:
@@ -93,7 +92,7 @@ apiServerExtraVolumes:
     mountPath: /etc/kubernetes/admission-control/
     writable: false
     pathType: Directory
-  {{ if .CloudProvider }}
+  {{ if and .CloudProvider .CloudConfig }}
   - name: cloud-config
     hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf
     mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
@@ -105,11 +104,11 @@ controllerManagerExtraArgs:
   {{ if .ControllerManagerSigningCA }}cluster-signing-cert-file: {{ .ControllerManagerSigningCA }}{{end}}
   {{ if .CloudProvider }}
   cloud-provider: "{{ .CloudProvider }}"
-  cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf
+  {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf
 controllerManagerExtraVolumes:
   - name: cloud-config
     hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf
-    mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
+    mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}
 etcd:
   {{ if .EtcdEndpoints }}
   external:

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.go
@@ -29,8 +29,7 @@ func kubeadmConfigV1Beta1Template() string {
 		"      value: \"{{.Value}}\"\n" +
 		"      effect: \"{{.Effect}}\"{{end}}\n" +
 		"  kubeletExtraArgs:\n" +
-		"    {{ if .Nodepool }}\n" +
-		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
+		"    {{ if .NodeLabels }}node-labels: \"{{ .NodeLabels }}\"{{end}}\n" +
 		"    # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker\n" +
 		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
 		"    {{ if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}{{end}}\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.go
@@ -32,9 +32,8 @@ func kubeadmConfigV1Beta1Template() string {
 		"    {{ if .Nodepool }}\n" +
 		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
 		"    # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker\n" +
-		"    {{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
-		"    {{if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
+		"    {{ if .KubeletCloudConfig }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}{{end}}\n" +
 		"    read-only-port: \"0\"\n" +
 		"    anonymous-auth: \"false\"\n" +
 		"    streaming-connection-idle-timeout: \"5m\"\n" +
@@ -85,9 +84,8 @@ func kubeadmConfigV1Beta1Template() string {
 		"    oidc-username-claim: \"email\"\n" +
 		"    oidc-username-prefix: \"oidc:\"\n" +
 		"    oidc-groups-claim: \"groups\"{{end}}\n" +
-		"    {{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"\n" +
-		"    cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
+		"    {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}\n" +
 		"  extraVolumes:\n" +
 		"    {{ if .WithAuditLog }}\n" +
 		"    - name: audit-log-dir\n" +
@@ -109,7 +107,7 @@ func kubeadmConfigV1Beta1Template() string {
 		"      mountPath: /etc/kubernetes/admission-control/\n" +
 		"      readOnly: true\n" +
 		"      pathType: Directory\n" +
-		"    {{ if .CloudProvider }}\n" +
+		"    {{ if and .CloudProvider .CloudConfig }}\n" +
 		"    - name: cloud-config\n" +
 		"      hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
 		"      mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
@@ -123,13 +121,12 @@ func kubeadmConfigV1Beta1Template() string {
 		"    terminated-pod-gc-threshold: \"10\"\n" +
 		"    feature-gates: \"RotateKubeletServerCertificate=true\"\n" +
 		"    {{ if .ControllerManagerSigningCA }}cluster-signing-cert-file: {{ .ControllerManagerSigningCA }}{{end}}\n" +
-		"    {{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"\n" +
-		"    cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
+		"    {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
 		"  extraVolumes:\n" +
 		"    - name: cloud-config\n" +
 		"      hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf\n" +
-		"      mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}\n" +
+		"      mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}\n" +
 		"etcd:\n" +
 		"  {{ if .EtcdEndpoints }}\n" +
 		"  external:\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.tmpl
@@ -11,8 +11,7 @@ nodeRegistration:
       value: "{{.Value}}"
       effect: "{{.Effect}}"{{end}}
   kubeletExtraArgs:
-    {{ if .Nodepool }}
-    node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
+    {{ if .NodeLabels }}node-labels: "{{ .NodeLabels }}"{{end}}
     # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker
     {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
     {{ if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}{{end}}

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1beta1.yaml.tmpl
@@ -14,9 +14,8 @@ nodeRegistration:
     {{ if .Nodepool }}
     node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
     # pod-infra-container-image: {{ .ImageRepository }}/pause:3.1 # only needed by docker
-    {{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"{{end}}
-    {{if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
+    {{ if .KubeletCloudConfig }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}{{end}}
     read-only-port: "0"
     anonymous-auth: "false"
     streaming-connection-idle-timeout: "5m"
@@ -67,9 +66,8 @@ apiServer:
     oidc-username-claim: "email"
     oidc-username-prefix: "oidc:"
     oidc-groups-claim: "groups"{{end}}
-    {{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"
-    cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
+    {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}
   extraVolumes:
     {{ if .WithAuditLog }}
     - name: audit-log-dir
@@ -91,7 +89,7 @@ apiServer:
       mountPath: /etc/kubernetes/admission-control/
       readOnly: true
       pathType: Directory
-    {{ if .CloudProvider }}
+    {{ if and .CloudProvider .CloudConfig }}
     - name: cloud-config
       hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf
       mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
@@ -105,13 +103,12 @@ controllerManager:
     terminated-pod-gc-threshold: "10"
     feature-gates: "RotateKubeletServerCertificate=true"
     {{ if .ControllerManagerSigningCA }}cluster-signing-cert-file: {{ .ControllerManagerSigningCA }}{{end}}
-    {{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"
-    cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"
+    {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf
   extraVolumes:
     - name: cloud-config
       hostPath: /etc/kubernetes/{{ .CloudProvider }}.conf
-      mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}
+      mountPath: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}
 etcd:
   {{ if .EtcdEndpoints }}
   external:

--- a/cmd/pke/app/phases/kubeadm/controlplane/lb.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/lb.go
@@ -20,6 +20,7 @@ import (
 	"text/template"
 
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 )
 
@@ -59,16 +60,13 @@ func writeLbRangeConfig(out io.Writer, filename, lbRange string) error {
 		return err
 	}
 
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
+	type data struct {
+		Range string
 	}
-	defer func() { _ = w.Close() }()
 
-	type data struct{ Range string }
+	d := data{
+		Range: lbRange,
+	}
 
-	d := data{Range: lbRange}
-
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }

--- a/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
@@ -42,7 +42,7 @@ func applyDefaultStorageClass(out io.Writer, disableDefaultStorageClass bool, cl
 		err = writeStorageClassVsphere(out, storageClassConfig)
 	case constants.CloudProviderExternal:
 		// TODO: out-of-tree CSI volume plugins
-		break
+		return nil
 	default:
 		err = writeStorageClassLocalPathStorage(out, storageClassConfig)
 	}

--- a/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
@@ -39,6 +39,9 @@ func applyDefaultStorageClass(out io.Writer, disableDefaultStorageClass bool, cl
 		err = writeStorageClassAzure(out, storageClassConfig, azureStorageAccountType, azureStorageKind)
 	case constants.CloudProviderVsphere:
 		err = writeStorageClassVsphere(out, storageClassConfig)
+	case constants.CloudProviderExternal:
+		// TODO: out-of-tree CSI volume plugins
+		break
 	default:
 		err = writeStorageClassLocalPathStorage(out, storageClassConfig)
 	}

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm.go
@@ -15,15 +15,13 @@
 package node
 
 import (
-	"fmt"
 	"io"
 	"net"
-	"os"
-	"path/filepath"
 	"text/template"
 
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/kubernetes"
 	"github.com/pbnjay/memory"
 	"github.com/pkg/errors"
@@ -33,14 +31,6 @@ import (
 //go:generate templify -t ${GOTMPL} -p node -f kubeadmConfigV1Beta1 kubeadm_v1beta1.yaml.tmpl
 
 func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
-	dir := filepath.Dir(filename)
-
-	_, _ = fmt.Fprintf(out, "[%s] creating directory: %q\n", use, dir)
-	err := os.MkdirAll(dir, 0750)
-	if err != nil {
-		return err
-	}
-
 	// API server advertisement
 	bindPort := "6443"
 	if n.advertiseAddress != "" {
@@ -83,13 +73,6 @@ func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
 		return err
 	}
 
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
-
 	taints, err := kubernetes.ParseTaints(n.taints)
 	if err != nil {
 		return err
@@ -127,5 +110,5 @@ func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
 		KubeReservedMemory:        kubeReservedMemory,
 	}
 
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm.go
@@ -17,6 +17,7 @@ package node
 import (
 	"io"
 	"net"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -84,6 +85,12 @@ func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
 		kubeReservedMemory = kubeadm.KubeReservedMemory(memory.TotalMemory())
 	)
 
+	// Node labels
+	nodeLabels := n.labels
+	if n.nodepool != "" {
+		nodeLabels = append(nodeLabels, "nodepool.banzaicloud.io/name="+n.nodepool)
+	}
+
 	type data struct {
 		APIServerAdvertiseAddress string
 		APIServerBindPort         string
@@ -91,7 +98,7 @@ func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
 		Token                     string
 		CACertHash                string
 		CloudProvider             string
-		Nodepool                  string
+		NodeLabels                string
 		Taints                    []kubernetes.Taint
 		KubeReservedCPU           string
 		KubeReservedMemory        string
@@ -104,7 +111,7 @@ func (n Node) writeKubeadmConfig(out io.Writer, filename string) error {
 		Token:                     n.kubeadmToken,
 		CACertHash:                n.caCertHash,
 		CloudProvider:             n.cloudProvider,
-		Nodepool:                  n.nodepool,
+		NodeLabels:                strings.Join(nodeLabels, ","),
 		Taints:                    taints,
 		KubeReservedCPU:           kubeReservedCPU,
 		KubeReservedMemory:        kubeReservedMemory,

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1alpha3.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1alpha3.yaml.go
@@ -29,10 +29,8 @@ func kubeadmConfigV1Alpha3Template() string {
 		"      value: \"{{.Value}}\"\n" +
 		"      effect: \"{{.Effect}}\"{{end}}\n" +
 		"  kubeletExtraArgs:\n" +
-		"{{ if .Nodepool }}\n" +
-		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
-		"{{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
+		"    {{ if .NodeLabels }}node-labels: \"{{ .NodeLabels }}\"{{end}}\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
 		"    {{if eq .CloudProvider \"azure\" }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}\n" +
 		"    read-only-port: \"0\"\n" +
 		"    anonymous-auth: \"false\"\n" +

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1alpha3.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1alpha3.yaml.tmpl
@@ -11,10 +11,8 @@ nodeRegistration:
       value: "{{.Value}}"
       effect: "{{.Effect}}"{{end}}
   kubeletExtraArgs:
-{{ if .Nodepool }}
-    node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
-{{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"{{end}}
+    {{ if .NodeLabels }}node-labels: "{{ .NodeLabels }}"{{end}}
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"{{end}}
     {{if eq .CloudProvider "azure" }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}
     read-only-port: "0"
     anonymous-auth: "false"

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta1.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta1.yaml.go
@@ -30,10 +30,8 @@ func kubeadmConfigV1Beta1Template() string {
 		"      value: \"{{.Value}}\"\n" +
 		"      effect: \"{{.Effect}}\"{{end}}\n" +
 		"  kubeletExtraArgs:\n" +
-		"{{ if .Nodepool }}\n" +
-		"    node-labels: \"nodepool.banzaicloud.io/name={{ .Nodepool }}\"{{end}}\n" +
-		"{{ if .CloudProvider }}\n" +
-		"    cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
+		"    {{ if .NodeLabels }}node-labels: \"{{ .NodeLabels }}\"{{end}}\n" +
+		"    {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"{{end}}\n" +
 		"    {{if eq .CloudProvider \"azure\" }}cloud-config: \"/etc/kubernetes/{{ .CloudProvider }}.conf\"{{end}}\n" +
 		"    read-only-port: \"0\"\n" +
 		"    anonymous-auth: \"false\"\n" +

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta1.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta1.yaml.tmpl
@@ -12,10 +12,8 @@ nodeRegistration:
       value: "{{.Value}}"
       effect: "{{.Effect}}"{{end}}
   kubeletExtraArgs:
-{{ if .Nodepool }}
-    node-labels: "nodepool.banzaicloud.io/name={{ .Nodepool }}"{{end}}
-{{ if .CloudProvider }}
-    cloud-provider: "{{ .CloudProvider }}"{{end}}
+    {{ if .NodeLabels }}node-labels: "{{ .NodeLabels }}"{{end}}
+    {{ if .CloudProvider }}cloud-provider: "{{ .CloudProvider }}"{{end}}
     {{if eq .CloudProvider "azure" }}cloud-config: "/etc/kubernetes/{{ .CloudProvider }}.conf"{{end}}
     read-only-port: "0"
     anonymous-auth: "false"

--- a/cmd/pke/app/phases/kubeadm/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/node/node.go
@@ -325,13 +325,6 @@ func writeCNIBridge(out io.Writer, cloudProvider, podNetworkCIDR, filename strin
 		return err
 	}
 
-	// create and truncate write only file
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = w.Close() }()
-
 	type data struct {
 		PodNetworkCIDR string
 	}
@@ -340,7 +333,7 @@ func writeCNIBridge(out io.Writer, cloudProvider, podNetworkCIDR, filename strin
 		PodNetworkCIDR: podNetworkCIDR,
 	}
 
-	return tmpl.Execute(w, d)
+	return file.WriteTemplate(filename, tmpl, d)
 }
 
 //go:generate templify -t ${GOTMPL} -p node -f cniLoopback cni_loopback.json.tmpl

--- a/cmd/pke/app/phases/kubeadm/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/node/node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/flags"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 	pipelineutil "github.com/banzaicloud/pke/cmd/pke/app/util/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
@@ -69,6 +70,7 @@ type Node struct {
 	azureLoadBalancerSku   string
 	azureRouteTableName    string
 	taints                 []string
+	labels                 []string
 }
 
 func NewCommand() *cobra.Command {
@@ -116,6 +118,8 @@ func (n *Node) RegisterFlags(flags *pflag.FlagSet) {
 	flags.String(constants.FlagAzureRouteTableName, "kubernetes-routes", "The name of the route table attached to the subnet that the cluster is deployed in")
 	// Taints
 	flags.StringSlice(constants.FlagTaints, nil, "Specifies the taints the Node should be registered with")
+	// Labels
+	flags.StringSlice(constants.FlagLabels, nil, "Specifies the labels the Node should be registered with")
 }
 
 func (n *Node) Validate(cmd *cobra.Command) error {
@@ -147,6 +151,8 @@ func (n *Node) Validate(cmd *cobra.Command) error {
 			return err
 		}
 	}
+
+	flags.PrintFlags(cmd.OutOrStdout(), n.Use(), cmd.Flags())
 
 	return nil
 }
@@ -239,6 +245,10 @@ func (n *Node) workerBootstrapParameters(cmd *cobra.Command) (err error) {
 		return
 	}
 	n.taints, err = cmd.Flags().GetStringSlice(constants.FlagTaints)
+	if err != nil {
+		return
+	}
+	n.labels, err = cmd.Flags().GetStringSlice(constants.FlagLabels)
 
 	return
 }

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/flags"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
@@ -79,6 +80,8 @@ func (c *ControlPlane) Validate(cmd *cobra.Command) error {
 	}
 
 	c.kubernetesAdditionalControlPlane, err = cmd.Flags().GetBool(constants.FlagAdditionalControlPlane)
+
+	flags.PrintFlags(cmd.OutOrStdout(), c.Use(), cmd.Flags())
 
 	return err
 }

--- a/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade"
+	"github.com/banzaicloud/pke/cmd/pke/app/util/flags"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
@@ -74,6 +75,8 @@ func (n *Node) Validate(cmd *cobra.Command) error {
 	}); err != nil {
 		return err
 	}
+
+	flags.PrintFlags(cmd.OutOrStdout(), n.Use(), cmd.Flags())
 
 	return nil
 }

--- a/cmd/pke/app/phases/runtime/container/containerd_linux.go
+++ b/cmd/pke/app/phases/runtime/container/containerd_linux.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	containerDVersion     = "1.2.7"
-	containerDSHA256      = "f6d4c4cd491b7ba42a4a1e9175425e238c47d8a1e7d755139946d926f3f31cff"
+	containerDVersion     = "1.2.9"
+	containerDSHA256      = "a1e8d3f6427f3146d8a3cce7a5d5fd55db0365697ece91506f74d116bdf0dff3"
 	containerDURL         = "https://storage.googleapis.com/cri-containerd-release/cri-containerd-%s.linux-amd64.tar.gz"
 	containerDVersionPath = "/opt/containerd/cluster/version"
 	containerDConf        = "/etc/containerd/config.toml"

--- a/cmd/pke/app/util/file/template.go
+++ b/cmd/pke/app/util/file/template.go
@@ -1,0 +1,42 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+// WriteTemplate write template output to file
+func WriteTemplate(filename string, tmpl *template.Template, data interface{}) error {
+	return WriteTemplateFlagPerm(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640, tmpl, data)
+}
+
+// WriteTemplateFlagPerm write template output to file with given flag and permission
+func WriteTemplateFlagPerm(filename string, flag int, perm os.FileMode, tmpl *template.Template, data interface{}) error {
+	err := os.MkdirAll(filepath.Dir(filename), perm|0110)
+	if err != nil {
+		return err
+	}
+
+	w, err := os.OpenFile(filename, flag, perm)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = w.Close() }()
+
+	return tmpl.Execute(w, data)
+}

--- a/cmd/pke/app/util/flags/flags.go
+++ b/cmd/pke/app/util/flags/flags.go
@@ -1,0 +1,29 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/pflag"
+)
+
+// PrintFlags logs the flags in the flagset
+func PrintFlags(out io.Writer, component string, flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		_, _ = fmt.Fprintf(out, "[%s] Flag --%s=%q\n", component, flag.Name, flag.Value)
+	})
+}

--- a/cmd/pke/docs/pke_install_master.md
+++ b/cmd/pke/docs/pke_install_master.md
@@ -45,6 +45,7 @@ pke install master [flags]
       --kubernetes-master-mode string                     Kubernetes cluster mode (default "default")
       --kubernetes-mtu uint                               maximum transmission unit. 0 means default value of the Kubernetes network provider is used
       --kubernetes-network-provider string                Kubernetes network provider (default "weave")
+      --kubernetes-node-labels strings                    Specifies the labels the Node should be registered with
       --kubernetes-node-token string                      PKE join token
       --kubernetes-oidc-client-id string                  A client ID that all OIDC tokens must be issued for
       --kubernetes-oidc-issuer-url string                 URL of the OIDC provider which allows the API server to discover public signing keys

--- a/cmd/pke/docs/pke_install_master_kubernetes-controlplane.md
+++ b/cmd/pke/docs/pke_install_master_kubernetes-controlplane.md
@@ -45,6 +45,7 @@ pke install master kubernetes-controlplane [flags]
       --kubernetes-master-mode string                     Kubernetes cluster mode (default "default")
       --kubernetes-mtu uint                               maximum transmission unit. 0 means default value of the Kubernetes network provider is used
       --kubernetes-network-provider string                Kubernetes network provider (default "weave")
+      --kubernetes-node-labels strings                    Specifies the labels the Node should be registered with
       --kubernetes-node-token string                      PKE join token
       --kubernetes-oidc-client-id string                  A client ID that all OIDC tokens must be issued for
       --kubernetes-oidc-issuer-url string                 URL of the OIDC provider which allows the API server to discover public signing keys

--- a/cmd/pke/docs/pke_install_single.md
+++ b/cmd/pke/docs/pke_install_single.md
@@ -45,6 +45,7 @@ pke install single [flags]
       --kubernetes-master-mode string                     Kubernetes cluster mode (default "default")
       --kubernetes-mtu uint                               maximum transmission unit. 0 means default value of the Kubernetes network provider is used
       --kubernetes-network-provider string                Kubernetes network provider (default "weave")
+      --kubernetes-node-labels strings                    Specifies the labels the Node should be registered with
       --kubernetes-node-token string                      PKE join token
       --kubernetes-oidc-client-id string                  A client ID that all OIDC tokens must be issued for
       --kubernetes-oidc-issuer-url string                 URL of the OIDC provider which allows the API server to discover public signing keys

--- a/cmd/pke/docs/pke_install_single_kubernetes-controlplane.md
+++ b/cmd/pke/docs/pke_install_single_kubernetes-controlplane.md
@@ -45,6 +45,7 @@ pke install single kubernetes-controlplane [flags]
       --kubernetes-master-mode string                     Kubernetes cluster mode (default "default")
       --kubernetes-mtu uint                               maximum transmission unit. 0 means default value of the Kubernetes network provider is used
       --kubernetes-network-provider string                Kubernetes network provider (default "weave")
+      --kubernetes-node-labels strings                    Specifies the labels the Node should be registered with
       --kubernetes-node-token string                      PKE join token
       --kubernetes-oidc-client-id string                  A client ID that all OIDC tokens must be issued for
       --kubernetes-oidc-issuer-url string                 URL of the OIDC provider which allows the API server to discover public signing keys

--- a/cmd/pke/docs/pke_install_worker.md
+++ b/cmd/pke/docs/pke_install_worker.md
@@ -27,6 +27,7 @@ pke install worker [flags]
       --kubernetes-api-server-ca-cert-hash string   CA cert hash
       --kubernetes-cloud-provider string            cloud provider. example: aws
       --kubernetes-infrastructure-cidr string       network CIDR for the actual machine (default "192.168.64.0/20")
+      --kubernetes-node-labels strings              Specifies the labels the Node should be registered with
       --kubernetes-node-token string                PKE join token
       --kubernetes-pod-network-cidr string          range of IP addresses for the pod network on the current node
       --kubernetes-version string                   Kubernetes version (default "1.14.3")

--- a/cmd/pke/docs/pke_install_worker_kubernetes-node.md
+++ b/cmd/pke/docs/pke_install_worker_kubernetes-node.md
@@ -25,6 +25,7 @@ pke install worker kubernetes-node [flags]
       --kubernetes-api-server string                Kubernetes API Server host port
       --kubernetes-api-server-ca-cert-hash string   CA cert hash
       --kubernetes-cloud-provider string            cloud provider. example: aws
+      --kubernetes-node-labels strings              Specifies the labels the Node should be registered with
       --kubernetes-node-token string                PKE join token
       --kubernetes-pod-network-cidr string          range of IP addresses for the pod network on the current node
       --kubernetes-version string                   Kubernetes version (default "1.14.3")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes
| License         | Apache 2.0


### What's in this PR?
Support for external cloud provider configuration.

### Why?
Kubernetes heading towards [Out-of-Tree Providers](https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/).

### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
