### PR TITLE
circleci: trigger pke image build after release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,28 @@ jobs:
                 run:
                     name: Invalidate cloudfront edge cache
                     command: |
-                     aws cloudfront create-invalidation \
-                       --distribution-id ${CDN_DISTRIBUTION_ID} \
-                       --paths "/downloads/pke/*"
+                       aws cloudfront create-invalidation \
+                           --distribution-id ${CDN_DISTRIBUTION_ID} \
+                           --paths "/downloads/pke/*"
+
+
+
+    trigger-pke-image-build:
+        docker:
+            -
+                image: circleci/golang:1.12
+        resource_class: small
+        steps:
+            - checkout
+            -
+                run:
+                    name: Create tag
+                    command: |
+                        scripts/create-git-tag.sh 'banzaicloud' 'pke-image' 'refs/heads/automated-build' "pke-${CIRCLE_TAG}"
 
 workflows:
     version: 2
-    build:
+    ci:
         jobs:
             -
                 build:
@@ -155,6 +170,15 @@ workflows:
                             ignore: /.*/
             -
                 cdn-invalidate:
+                    requires:
+                        - release
+                    filters:
+                        tags:
+                            only: /^v?\d+\.\d+\.\d+(-\S*)?$/
+                        branches:
+                            ignore: /.*/
+            -
+                trigger-pke-image-build:
                     requires:
                         - release
                     filters:

--- a/create-git-tag.sh
+++ b/create-git-tag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euf
+
+OWNER="$1"
+REPO="$2"
+REF="$3"
+TAG="$4"
+
+API_URL="https://api.github.com/repos/${OWNER}/${REPO}"
+
+SHA=$(curl -sS -X GET -H "Authorization: token $GITHUB_TOKEN" "${API_URL}/git/${REF}" | jq -r '.object.sha')
+
+curl \
+    -sS \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"sha": "'"${SHA}"'", "ref": "refs/tags/'"${TAG}"'"}' \
+    "${API_URL}/git/refs"

--- a/scripts/create-git-tag.sh
+++ b/scripts/create-git-tag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -euf
+
+OWNER="$1"
+REPO="$2"
+REF="$3"
+TAG="$4"
+
+API_URL="https://api.github.com/repos/${OWNER}/${REPO}"
+
+SHA=$(curl -sS -X GET -H "Authorization: token ${GITHUB_TOKEN}" "${API_URL}/git/${REF}" | jq -r '.object.sha')
+
+curl \
+    -sS \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"sha": "'"${SHA}"'", "ref": "refs/tags/'"${TAG}"'"}' \
+    "${API_URL}/git/refs"


### PR DESCRIPTION
The simplest way to trigger another repo's ci flow is to create a git tag on it.