### PR TITLE
Kernel modules

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -8,5 +8,8 @@ approved = [
 
 
 ignored = [
+    "emperror.dev/errors",
     "github.com/ghodss/yaml",
+    "go.uber.org/atomic",
+    "go.uber.org/multierr",
 ]

--- a/cmd/pke/app/cmd/version.go
+++ b/cmd/pke/app/cmd/version.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"runtime"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/pke/app/constants/constants.go
+++ b/cmd/pke/app/constants/constants.go
@@ -15,7 +15,7 @@
 package constants
 
 import (
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 const (

--- a/cmd/pke/app/phases/kubeadm/common.go
+++ b/cmd/pke/app/phases/kubeadm/common.go
@@ -25,10 +25,10 @@ import (
 	"text/template"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
@@ -31,6 +31,7 @@ import (
 	"text/template"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/.gen/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
@@ -47,7 +48,6 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
 	"github.com/goph/emperror"
 	"github.com/lestrrat-go/backoff"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 	"text/template"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/kubernetes"
 	"github.com/pbnjay/memory"
-	"github.com/pkg/errors"
 )
 
 //go:generate templify -t ${GOTMPL} -p controlplane -f kubeadmConfigV1Alpha3 kubeadm_v1alpha3.yaml.tmpl

--- a/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/kubeadm_v1alpha3.yaml.go
@@ -83,8 +83,7 @@ func kubeadmConfigV1Alpha3Template() string {
 		"  oidc-username-claim: \"email\"\n" +
 		"  oidc-username-prefix: \"oidc:\"\n" +
 		"  oidc-groups-claim: \"groups\"{{end}}\n" +
-		"  {{ if .CloudProvider }}\n" +
-		"  cloud-provider: \"{{ .CloudProvider }}\"\n" +
+		"  {{ if .CloudProvider }}cloud-provider: \"{{ .CloudProvider }}\"\n" +
 		"  {{ if .CloudConfig }}cloud-config: /etc/kubernetes/{{ .CloudProvider }}.conf{{end}}{{end}}\n" +
 		"schedulerExtraArgs:\n" +
 		"  profiling: \"false\"\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/storage_class.go
@@ -21,10 +21,10 @@ import (
 	"os/exec"
 	"text/template"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 func applyDefaultStorageClass(out io.Writer, disableDefaultStorageClass bool, cloudProvider string, azureStorageAccountType, azureStorageKind string) error {

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"text/template"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/kubernetes"
 	"github.com/pbnjay/memory"
-	"github.com/pkg/errors"
 )
 
 //go:generate templify -t ${GOTMPL} -p node -f kubeadmConfigV1Alpha3 kubeadm_v1alpha3.yaml.tmpl

--- a/cmd/pke/app/phases/kubeadm/token/create/create.go
+++ b/cmd/pke/app/phases/kubeadm/token/create/create.go
@@ -25,12 +25,12 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/token"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/kubeadm/token/list/list.go
+++ b/cmd/pke/app/phases/kubeadm/token/list/list.go
@@ -24,12 +24,12 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/token"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/kubeadm/token/token.go
+++ b/cmd/pke/app/phases/kubeadm/token/token.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
@@ -26,7 +27,6 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
@@ -26,7 +27,6 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/kubeadm/version/version.go
+++ b/cmd/pke/app/phases/kubeadm/version/version.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"io"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/pipeline/certificates/certificates.go
+++ b/cmd/pke/app/phases/pipeline/certificates/certificates.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"emperror.dev/errors"
 	"github.com/antihax/optional"
 	"github.com/banzaicloud/pke/.gen/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
@@ -27,7 +28,6 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	pipelineutil "github.com/banzaicloud/pke/cmd/pke/app/util/pipeline"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/pipeline/ready/ready.go
+++ b/cmd/pke/app/phases/pipeline/ready/ready.go
@@ -22,13 +22,13 @@ import (
 	"io/ioutil"
 	"os"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/.gen/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/network"
 	pipelineutil "github.com/banzaicloud/pke/cmd/pke/app/util/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/pke/app/phases/runtime/container/containerd_linux.go
+++ b/cmd/pke/app/phases/runtime/container/containerd_linux.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"text/template"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/phases/runtime/container/containerd_other.go
+++ b/cmd/pke/app/phases/runtime/container/containerd_other.go
@@ -19,7 +19,7 @@ package container
 import (
 	"io"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func (r *Runtime) installRuntime(w io.Writer) error {

--- a/cmd/pke/app/phases/runtime/kubernetes/kubernetes_linux.go
+++ b/cmd/pke/app/phases/runtime/kubernetes/kubernetes_linux.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/phases/runtime/kubernetes/kubernetes_other.go
+++ b/cmd/pke/app/phases/runtime/kubernetes/kubernetes_other.go
@@ -19,7 +19,7 @@ package kubernetes
 import (
 	"io"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func (r *Runtime) installRuntime(w io.Writer) error {

--- a/cmd/pke/app/util/file/download.go
+++ b/cmd/pke/app/util/file/download.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func Download(u *url.URL, f string) error {

--- a/cmd/pke/app/util/file/tar.go
+++ b/cmd/pke/app/util/file/tar.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func Untar(out io.Writer, r io.Reader) error {

--- a/cmd/pke/app/util/file/write.go
+++ b/cmd/pke/app/util/file/write.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func Overwrite(file, contents string) error {

--- a/cmd/pke/app/util/kubernetes/taint.go
+++ b/cmd/pke/app/util/kubernetes/taint.go
@@ -17,7 +17,7 @@ package kubernetes
 import (
 	"strings"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 type Taint struct {

--- a/cmd/pke/app/util/linux/apt.go
+++ b/cmd/pke/app/util/linux/apt.go
@@ -20,10 +20,10 @@ import (
 	"net/url"
 	"os"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/util/linux/apt.go
+++ b/cmd/pke/app/util/linux/apt.go
@@ -49,29 +49,8 @@ func (a *AptInstaller) InstallKubernetesPrerequisites(out io.Writer, kubernetesV
 		return err
 	}
 
-	// modprobe nf_conntrack_ipv4
-	if err := Modprobe(out, "nf_conntrack_ipv4"); err != nil {
-		return errors.Wrap(err, "missing nf_conntrack_ipv4 Linux Kernel module")
-	}
-
-	// modprobe ip_vs
-	if err := Modprobe(out, "ip_vs"); err != nil {
-		return errors.Wrap(err, "missing ip_vs Linux Kernel module")
-	}
-
-	// modprobe ip_vs_rr
-	if err := Modprobe(out, "ip_vs_rr"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_rr Linux Kernel module")
-	}
-
-	// modprobe ip_vs_wrr
-	if err := Modprobe(out, "ip_vs_wrr"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_wrr Linux Kernel module")
-	}
-
-	// modprobe ip_vs_sh
-	if err := Modprobe(out, "ip_vs_sh"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_sh Linux Kernel module")
+	if err := ModprobeKubeProxyIPVSModules(out); err != nil {
+		return err
 	}
 
 	if err := SysctlLoadAllFiles(out); err != nil {

--- a/cmd/pke/app/util/linux/kernel.go
+++ b/cmd/pke/app/util/linux/kernel.go
@@ -17,23 +17,26 @@ package linux
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 func KernelVersionConstraint(out io.Writer, constraint string) error {
-	// uname -r
-	version, err := runner.Cmd(out, "uname", "-r").CombinedOutput()
+	version, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		version, err = runner.Cmd(out, "uname", "-r").CombinedOutput()
+	}
 	if err != nil {
 		return err
 	}
 	v := string(bytes.TrimSpace(version))
 	ver, err := semver.NewVersion(v)
 	if err != nil {
-		return errors.Wrapf(err, "got version: %s", v)
+		return errors.Wrapf(err, "got kernel version: %s", v)
 	}
 
 	c, err := semver.NewConstraint(constraint)

--- a/cmd/pke/app/util/linux/modprobe.go
+++ b/cmd/pke/app/util/linux/modprobe.go
@@ -17,6 +17,8 @@ package linux
 import (
 	"io"
 
+	"emperror.dev/errors"
+	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 )
 
@@ -34,4 +36,42 @@ func ModprobeOverlay(out io.Writer) error {
 
 func ModprobeBRNetFilter(out io.Writer) error {
 	return Modprobe(out, "br_netfilter")
+}
+
+func kubeProxyIPVSModules(out io.Writer) ([]string, error) {
+	modules := []string{
+		"ip_vs",
+		"ip_vs_rr",
+		"ip_vs_wrr",
+		"ip_vs_sh",
+	}
+
+	// https://github.com/kubernetes/kubernetes/blob/d5d7db476d044c7489c120e20f07b1283a81310d/pkg/proxy/ipvs/README.md#prerequisite
+	conntrack := "nf_conntrack_ipv4"
+	err := KernelVersionConstraint(out, "<4.19")
+	if errors.Is(err, constants.ErrUnsupportedKernelVersion) {
+		err = nil
+		conntrack = "nf_conntrack"
+	}
+	if err != nil {
+		return nil, err
+	}
+	modules = append(modules, conntrack)
+
+	return modules, nil
+}
+
+func ModprobeKubeProxyIPVSModules(out io.Writer) error {
+	modules, err := kubeProxyIPVSModules(out)
+	if err != nil {
+		return err
+	}
+	for _, module := range modules {
+		err = Modprobe(out, module)
+		if err != nil {
+			return errors.Wrapf(err, "missing %s Linux Kernel module", module)
+		}
+	}
+
+	return nil
 }

--- a/cmd/pke/app/util/linux/os_version_linux.go
+++ b/cmd/pke/app/util/linux/os_version_linux.go
@@ -19,8 +19,8 @@ import (
 	"io"
 	"strings"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/cmd/pke/app/util/linux/yum.go
+++ b/cmd/pke/app/util/linux/yum.go
@@ -139,29 +139,8 @@ func (y *YumInstaller) InstallKubernetesPrerequisites(out io.Writer, kubernetesV
 		return err
 	}
 
-	// modprobe nf_conntrack_ipv4
-	if err := Modprobe(out, "nf_conntrack_ipv4"); err != nil {
-		return errors.Wrap(err, "missing nf_conntrack_ipv4 Linux Kernel module")
-	}
-
-	// modprobe ip_vs
-	if err := Modprobe(out, "ip_vs"); err != nil {
-		return errors.Wrap(err, "missing ip_vs Linux Kernel module")
-	}
-
-	// modprobe ip_vs_rr
-	if err := Modprobe(out, "ip_vs_rr"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_rr Linux Kernel module")
-	}
-
-	// modprobe ip_vs_wrr
-	if err := Modprobe(out, "ip_vs_wrr"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_wrr Linux Kernel module")
-	}
-
-	// modprobe ip_vs_sh
-	if err := Modprobe(out, "ip_vs_sh"); err != nil {
-		return errors.Wrap(err, "missing ip_vs_sh Linux Kernel module")
+	if err := ModprobeKubeProxyIPVSModules(out); err != nil {
+		return err
 	}
 
 	if err := SysctlLoadAllFiles(out); err != nil {

--- a/cmd/pke/app/util/linux/yum.go
+++ b/cmd/pke/app/util/linux/yum.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"strings"
 
+	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/pke/app/util/network/cidr.go
+++ b/cmd/pke/app/util/network/cidr.go
@@ -17,7 +17,7 @@ package network
 import (
 	"net"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func Contains(cidr string, ip net.IP) (bool, error) {

--- a/cmd/pke/app/util/network/interfaces.go
+++ b/cmd/pke/app/util/network/interfaces.go
@@ -17,7 +17,7 @@ package network
 import (
 	"net"
 
-	"github.com/pkg/errors"
+	"emperror.dev/errors"
 )
 
 func IPv4Addresses() ([]net.IP, error) {

--- a/cmd/pke/app/util/validator/parameters.go
+++ b/cmd/pke/app/util/validator/parameters.go
@@ -15,8 +15,8 @@
 package validator
 
 import (
+	"emperror.dev/errors"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
-	"github.com/pkg/errors"
 )
 
 // NotEmpty gives error, if any of the given args is empty. Map key is returned in the error message.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/banzaicloud/pke
 go 1.12
 
 require (
+	emperror.dev/errors v0.4.3
 	github.com/Masterminds/semver v1.4.2
 	github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9
 	github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6
@@ -14,7 +15,6 @@ require (
 	github.com/goph/emperror v0.17.1
 	github.com/lestrrat-go/backoff v0.0.0-20190107202757-0bc2a4274cd0
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
-	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+emperror.dev/errors v0.4.3 h1:yfhVxX1vzHgCDXh0KL+gVKfKhXlJCabmc79jS6QQuus=
+emperror.dev/errors v0.4.3/go.mod h1:cA5SMsyzo+KXq997DKGK+lTV1DGx5TXLQUNtYe9p2p0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -84,6 +86,10 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
+go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Handles nf_conntrack kernel module name change for Linux Kernel 4.19 and later on.
- Changed github.com/pkg/errors to emperror.dev/errors.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Kernel module name `nf_conntrack_ipv4` is changed to `nf_conntrack`  for Linux Kernel 4.19 and later on.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
