### PR TITLE
Upgrade fails from 1.15.7 to 1.16.4 #83

### DIFF
--- a/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
@@ -110,10 +110,15 @@ func (n *Node) upgrade(out io.Writer, from, to *semver.Version) error {
 	args := []string{
 		"upgrade",
 		"node",
-		"config",
-		"--kubelet-version",
-		to.String(),
 	}
+	c, _ := semver.NewConstraint("<1.15")
+	if c.Check(to) {
+		args = append(args, "config")
+	}
+
+	// target version
+	args = append(args, "--kubelet-version", to.String())
+
 	_, err = runner.Cmd(out, cmdKubeadm, args...).CombinedOutputAsync()
 	if err != nil {
 		return err


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #83
| License         | Apache 2.0


### What's in this PR?
- There is a bug in kubeadm's CoreDNS configuration migration preflight check. This provides a workaround.
- Change deprecated kubeadm upgrade commands.

### Why?
Kubernetes upgrade fails.
