### PR TITLE
Fix v1beta2 node template

### DIFF
--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta2.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta2.yaml.go
@@ -16,7 +16,7 @@ package node
 
 // kubeadmConfigV1Beta2Template is a generated function returning the template as a string.
 func kubeadmConfigV1Beta2Template() string {
-	var tmpl = "kubeadm_v1beta1.yaml.tmplapiVersion: kubeadm.k8s.io/v1beta2\n" +
+	var tmpl = "apiVersion: kubeadm.k8s.io/v1beta2\n" +
 		"kind: JoinConfiguration\n" +
 		"{{ if and .APIServerAdvertiseAddress .APIServerBindPort }}\n" +
 		"controlPlane:\n" +

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta2.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm_v1beta2.yaml.tmpl
@@ -1,4 +1,4 @@
-kubeadm_v1beta1.yaml.tmplapiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: JoinConfiguration
 {{ if and .APIServerAdvertiseAddress .APIServerBindPort }}
 controlPlane:


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no|
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fixing v1beta2 kubeadm node template.