### PR TITLE
Use config

### DIFF
--- a/cmd/pke/app/cmd/cmd.go
+++ b/cmd/pke/app/cmd/cmd.go
@@ -15,6 +15,10 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/spf13/cobra"
 )
 
@@ -28,10 +32,16 @@ func NewPKECommand(gitVersion, gitCommit, gitTreeState, buildDate string) *cobra
 
 	cmd.ResetFlags()
 
-	cmd.AddCommand(NewCmdInstall())
+	c, err := config.Load()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	cmd.AddCommand(NewCmdInstall(c))
 	cmd.AddCommand(NewCmdImage())
 	cmd.AddCommand(NewCmdToken())
-	cmd.AddCommand(NewCmdUpgrade())
+	cmd.AddCommand(NewCmdUpgrade(c))
 	cmd.AddCommand(NewCmdVersion(gitVersion, gitCommit, gitTreeState, buildDate))
 
 	return cmd

--- a/cmd/pke/app/cmd/install.go
+++ b/cmd/pke/app/cmd/install.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/controlplane"
@@ -28,32 +29,32 @@ import (
 )
 
 // NewCmdInstall provides the version information of banzai-cloud-pke.
-func NewCmdInstall() *cobra.Command {
+func NewCmdInstall(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install a single Banzai Cloud Pipeline Kubernetes Engine (PKE) machine",
 		Args:  cobra.NoArgs,
 	}
 
-	cmd.AddCommand(single())
-	cmd.AddCommand(master())
-	cmd.AddCommand(worker())
+	cmd.AddCommand(single(c))
+	cmd.AddCommand(master(c))
+	cmd.AddCommand(worker(c))
 
 	return cmd
 }
 
-func master() *cobra.Command {
+func master(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "master",
 		Short: "Installs Banzai Cloud Pipeline Kubernetes Engine (PKE) Master node",
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(version.NewCommand())
-	cmd.AddCommand(container.NewCommand())
-	cmd.AddCommand(kubernetes.NewCommand())
-	cmd.AddCommand(certificates.NewCommand())
-	cmd.AddCommand(controlplane.NewCommand())
+	cmd.AddCommand(version.NewCommand(c))
+	cmd.AddCommand(container.NewCommand(c))
+	cmd.AddCommand(kubernetes.NewCommand(c))
+	cmd.AddCommand(certificates.NewCommand(c))
+	cmd.AddCommand(controlplane.NewCommand(c))
 	cmd.AddCommand(ready.NewCommand(ready.RoleMaster))
 
 	phases.MakeRunnable(cmd)
@@ -61,8 +62,8 @@ func master() *cobra.Command {
 	return cmd
 }
 
-func single() *cobra.Command {
-	m := master()
+func single(c config.Config) *cobra.Command {
+	m := master(c)
 	m.Use = "single"
 	m.Short = "Installs Banzai Cloud Pipeline Kubernetes Engine (PKE) on a single machine"
 	_ = m.Flags().Set(constants.FlagClusterMode, "single")
@@ -70,17 +71,17 @@ func single() *cobra.Command {
 	return m
 }
 
-func worker() *cobra.Command {
+func worker(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "worker",
 		Short: "Installs Banzai Cloud Pipeline Kubernetes Engine (PKE) Worker node",
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(version.NewCommand())
-	cmd.AddCommand(container.NewCommand())
-	cmd.AddCommand(kubernetes.NewCommand())
-	cmd.AddCommand(node.NewCommand())
+	cmd.AddCommand(version.NewCommand(c))
+	cmd.AddCommand(container.NewCommand(c))
+	cmd.AddCommand(kubernetes.NewCommand(c))
+	cmd.AddCommand(node.NewCommand(c))
 	cmd.AddCommand(ready.NewCommand(ready.RoleWorker))
 
 	phases.MakeRunnable(cmd)

--- a/cmd/pke/app/cmd/machine-image.go
+++ b/cmd/pke/app/cmd/machine-image.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/images"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/version"
@@ -32,11 +33,13 @@ func NewCmdImage() *cobra.Command {
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(version.NewCommand())
-	cmd.AddCommand(container.NewCommand())
-	cmd.AddCommand(kubernetes.NewCommand())
-	cmd.AddCommand(images.NewCommand())
-	cmd.AddCommand(writeconfig.NewCommand())
+	c := config.Default()
+
+	cmd.AddCommand(version.NewCommand(c))
+	cmd.AddCommand(container.NewCommand(c))
+	cmd.AddCommand(kubernetes.NewCommand(c))
+	cmd.AddCommand(images.NewCommand(c))
+	cmd.AddCommand(writeconfig.NewCommand(c))
 
 	phases.MakeRunnable(cmd)
 

--- a/cmd/pke/app/cmd/machine-image.go
+++ b/cmd/pke/app/cmd/machine-image.go
@@ -18,7 +18,7 @@ import (
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/images"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/version"
-	"github.com/banzaicloud/pke/cmd/pke/app/phases/machineimage/config"
+	"github.com/banzaicloud/pke/cmd/pke/app/phases/machineimage/writeconfig"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/runtime/container"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/runtime/kubernetes"
 	"github.com/spf13/cobra"
@@ -36,7 +36,7 @@ func NewCmdImage() *cobra.Command {
 	cmd.AddCommand(container.NewCommand())
 	cmd.AddCommand(kubernetes.NewCommand())
 	cmd.AddCommand(images.NewCommand())
-	cmd.AddCommand(config.NewCommand())
+	cmd.AddCommand(writeconfig.NewCommand())
 
 	phases.MakeRunnable(cmd)
 

--- a/cmd/pke/app/cmd/upgrade.go
+++ b/cmd/pke/app/cmd/upgrade.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade/controlplane"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade/node"
@@ -22,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdUpgrade() *cobra.Command {
+func NewCmdUpgrade(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade a single Banzai Cloud Pipeline Kubernetes Engine (PKE) machine",
@@ -30,13 +31,13 @@ func NewCmdUpgrade() *cobra.Command {
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(upgradeMaster())
-	cmd.AddCommand(upgradeWorker())
+	cmd.AddCommand(upgradeMaster(c))
+	cmd.AddCommand(upgradeWorker(c))
 
 	return cmd
 }
 
-func upgradeMaster() *cobra.Command {
+func upgradeMaster(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "master",
 		Short: "Upgrade a single Banzai Cloud Pipeline Kubernetes Engine (PKE) master machine",
@@ -44,15 +45,15 @@ func upgradeMaster() *cobra.Command {
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(version.NewCommand())
-	cmd.AddCommand(controlplane.NewCommand())
+	cmd.AddCommand(version.NewCommand(c))
+	cmd.AddCommand(controlplane.NewCommand(c))
 
 	phases.MakeRunnable(cmd)
 
 	return cmd
 }
 
-func upgradeWorker() *cobra.Command {
+func upgradeWorker(c config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "worker",
 		Short: "Upgrade a single Banzai Cloud Pipeline Kubernetes Engine (PKE) worker machine",
@@ -60,8 +61,8 @@ func upgradeWorker() *cobra.Command {
 		RunE:  phases.RunEAllSubcommands,
 	}
 
-	cmd.AddCommand(version.NewCommand())
-	cmd.AddCommand(node.NewCommand())
+	cmd.AddCommand(version.NewCommand(c))
+	cmd.AddCommand(node.NewCommand(c))
 
 	phases.MakeRunnable(cmd)
 

--- a/cmd/pke/app/config/default.go
+++ b/cmd/pke/app/config/default.go
@@ -1,0 +1,30 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+const DefaultKubernetesVersion = "1.17.5"
+
+func Default() Config {
+	return Config{
+		Kubernetes: KubernetesConfig{
+			Version:   DefaultKubernetesVersion,
+			Installed: false,
+		},
+		ContainerRuntime: ContainerRuntimeConfig{
+			Type:      "containerd",
+			Installed: false,
+		},
+	}
+}

--- a/cmd/pke/app/config/load.go
+++ b/cmd/pke/app/config/load.go
@@ -1,0 +1,69 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+const configPath = "/etc/banzaicloud/pke.yaml"
+
+// Load reads the configuration from the filesystem or returns the default config if it cannot be found.
+func Load() (config Config, err error) {
+	if !fileExists(configPath) {
+		return Default(), nil
+	}
+
+	b, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return config, fmt.Errorf("config read: %w", err)
+	}
+
+	err = yaml.Unmarshal(b, &config)
+	if err != nil {
+		return config, fmt.Errorf("config read: %w", err)
+	}
+
+	config = loadDefaults(config)
+
+	return config, nil
+}
+
+func loadDefaults(config Config) Config {
+	def := Default()
+
+	if config.Kubernetes.Version == "" {
+		config.Kubernetes.Version = def.Kubernetes.Version
+	}
+
+	if config.ContainerRuntime.Type == "" {
+		config.ContainerRuntime.Type = def.ContainerRuntime.Type
+	}
+
+	return config
+}
+
+func fileExists(fileName string) bool {
+	info, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return !info.IsDir()
+}

--- a/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
@@ -33,6 +33,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
 	"github.com/banzaicloud/pke/.gen/pipeline"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
@@ -81,6 +82,8 @@ const (
 var _ phases.Runnable = (*ControlPlane)(nil)
 
 type ControlPlane struct {
+	config config.Config
+
 	kubernetesVersion                string
 	containerRuntime                 string
 	networkProvider                  string
@@ -138,9 +141,10 @@ type ControlPlane struct {
 	encryptionSecret                 string
 }
 
-func NewCommand() *cobra.Command {
+func NewCommand(config config.Config) *cobra.Command {
 	return phases.NewCommand(&ControlPlane{
-		node: &node.Node{},
+		config: config,
+		node:   &node.Node{},
 	})
 }
 
@@ -162,9 +166,9 @@ func (c *ControlPlane) Short() string {
 
 func (c *ControlPlane) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, c.config.Kubernetes.Version, "Kubernetes version")
 	// Kubernetes container runtime
-	flags.String(constants.FlagContainerRuntime, "containerd", "Kubernetes container runtime")
+	flags.String(constants.FlagContainerRuntime, c.config.ContainerRuntime.Type, "Kubernetes container runtime")
 	// Kubernetes network
 	flags.String(constants.FlagNetworkProvider, "calico", "Kubernetes network provider")
 	flags.String(constants.FlagAdvertiseAddress, "", "Kubernetes API Server advertise address")

--- a/cmd/pke/app/phases/kubeadm/images/pull.go
+++ b/cmd/pke/app/phases/kubeadm/images/pull.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/Masterminds/semver"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/controlplane"
@@ -39,12 +40,14 @@ const (
 var _ phases.Runnable = (*Image)(nil)
 
 type Image struct {
+	config config.Config
+
 	kubernetesVersion string
 	imageRepository   string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&Image{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&Image{config: config})
 }
 
 func (i *Image) Use() string {
@@ -57,7 +60,7 @@ func (i *Image) Short() string {
 
 func (i *Image) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, i.config.Kubernetes.Version, "Kubernetes version")
 	// Image repository
 	flags.String(constants.FlagImageRepository, "banzaicloud", "Prefix for image repository")
 }

--- a/cmd/pke/app/phases/kubeadm/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/node/node.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
@@ -55,6 +56,8 @@ const (
 var _ phases.Runnable = (*Node)(nil)
 
 type Node struct {
+	config config.Config
+
 	kubernetesVersion      string
 	containerRuntime       string
 	advertiseAddress       string
@@ -76,8 +79,8 @@ type Node struct {
 	labels                 []string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&Node{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&Node{config: config})
 }
 
 func (n *Node) Use() string {
@@ -90,9 +93,9 @@ func (n *Node) Short() string {
 
 func (n *Node) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, n.config.Kubernetes.Version, "Kubernetes version")
 	// Kubernetes container runtime
-	flags.String(constants.FlagContainerRuntime, "containerd", "Kubernetes container runtime")
+	flags.String(constants.FlagContainerRuntime, n.config.ContainerRuntime.Type, "Kubernetes container runtime")
 	// Kubernetes network
 	flags.String(constants.FlagPodNetworkCIDR, "", "range of IP addresses for the pod network on the current node")
 	// Pipeline

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/controlplane.go
@@ -26,6 +26,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade"
@@ -55,6 +56,8 @@ const (
 var _ phases.Runnable = (*ControlPlane)(nil)
 
 type ControlPlane struct {
+	config config.Config
+
 	kubernetesVersion                string
 	kubernetesAdditionalControlPlane bool
 	kubeadmConfigMap                 kubeadmConfigMap
@@ -153,8 +156,8 @@ type kubeadmConfigMap struct {
 	UseHyperKubeImage bool `yaml:"useHyperKubeImage,omitempty"`
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&ControlPlane{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&ControlPlane{config: config})
 }
 
 func (*ControlPlane) Use() string {
@@ -165,9 +168,9 @@ func (*ControlPlane) Short() string {
 	return short
 }
 
-func (*ControlPlane) RegisterFlags(flags *pflag.FlagSet) {
+func (c *ControlPlane) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, c.config.Kubernetes.Version, "Kubernetes version")
 	// Additional Control Plane
 	flags.Bool(constants.FlagAdditionalControlPlane, false, "Treat node as additional control plane")
 }

--- a/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/node/node.go
@@ -20,6 +20,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm/upgrade"
@@ -42,11 +43,13 @@ const (
 var _ phases.Runnable = (*Node)(nil)
 
 type Node struct {
+	config config.Config
+
 	kubernetesVersion string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&Node{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&Node{config: config})
 }
 
 func (*Node) Use() string {
@@ -57,9 +60,9 @@ func (*Node) Short() string {
 	return short
 }
 
-func (*Node) RegisterFlags(flags *pflag.FlagSet) {
+func (n *Node) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, n.config.Kubernetes.Version, "Kubernetes version")
 }
 
 func (n *Node) Validate(cmd *cobra.Command) error {

--- a/cmd/pke/app/phases/kubeadm/version/version.go
+++ b/cmd/pke/app/phases/kubeadm/version/version.go
@@ -20,6 +20,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
@@ -37,11 +38,13 @@ const (
 var _ phases.Runnable = (*Version)(nil)
 
 type Version struct {
+	config config.Config
+
 	kubernetesVersion string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&Version{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&Version{config: config})
 }
 
 func (v *Version) Use() string {
@@ -54,7 +57,7 @@ func (v *Version) Short() string {
 
 func (v *Version) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, v.config.Kubernetes.Version, "Kubernetes version")
 }
 
 func (v *Version) Validate(cmd *cobra.Command) error {

--- a/cmd/pke/app/phases/machineimage/writeconfig/config.go
+++ b/cmd/pke/app/phases/machineimage/writeconfig/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package writeconfig
 
 import (
 	"fmt"

--- a/cmd/pke/app/phases/machineimage/writeconfig/config.go
+++ b/cmd/pke/app/phases/machineimage/writeconfig/config.go
@@ -39,12 +39,14 @@ const (
 var _ phases.Runnable = (*WriteConfig)(nil)
 
 type WriteConfig struct {
+	config config.Config
+
 	kubernetesVersion string
 	containerRuntime  string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&WriteConfig{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&WriteConfig{config: config})
 }
 
 func (w *WriteConfig) Use() string {
@@ -57,10 +59,10 @@ func (w *WriteConfig) Short() string {
 
 func (w *WriteConfig) RegisterFlags(flags *pflag.FlagSet) {
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, w.config.Kubernetes.Version, "Kubernetes version")
 
 	// Kubernetes container runtime
-	flags.String(constants.FlagContainerRuntime, "containerd", "Kubernetes container runtime")
+	flags.String(constants.FlagContainerRuntime, w.config.ContainerRuntime.Type, "Kubernetes container runtime")
 }
 
 func (w *WriteConfig) Validate(cmd *cobra.Command) (err error) {

--- a/cmd/pke/app/phases/machineimage/writeconfig/config_test.go
+++ b/cmd/pke/app/phases/machineimage/writeconfig/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package writeconfig
 
 import (
 	"io/ioutil"

--- a/cmd/pke/app/phases/pipeline/certificates/certificates.go
+++ b/cmd/pke/app/phases/pipeline/certificates/certificates.go
@@ -23,6 +23,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/antihax/optional"
 	"github.com/banzaicloud/pke/.gen/pipeline"
+	"github.com/banzaicloud/pke/cmd/pke/app/config"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
@@ -51,6 +52,8 @@ const (
 var _ phases.Runnable = (*Certificates)(nil)
 
 type Certificates struct {
+	config config.Config
+
 	pipelineEnabled        bool
 	pipelineAPIEndpoint    string
 	pipelineAPIToken       string
@@ -60,8 +63,8 @@ type Certificates struct {
 	kubernetesVersion      string
 }
 
-func NewCommand() *cobra.Command {
-	return phases.NewCommand(&Certificates{})
+func NewCommand(config config.Config) *cobra.Command {
+	return phases.NewCommand(&Certificates{config: config})
 }
 
 func (c *Certificates) Use() string {
@@ -80,7 +83,7 @@ func (c *Certificates) RegisterFlags(flags *pflag.FlagSet) {
 	flags.Int32(constants.FlagPipelineOrganizationID, 0, "Organization ID to use with Pipeline API")
 	flags.Int32(constants.FlagPipelineClusterID, 0, "Cluster ID to use with Pipeline API")
 	// Kubernetes version
-	flags.String(constants.FlagKubernetesVersion, "1.17.5", "Kubernetes version")
+	flags.String(constants.FlagKubernetesVersion, c.config.Kubernetes.Version, "Kubernetes version")
 }
 
 func (c *Certificates) Validate(cmd *cobra.Command) error {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #99
| License         | Apache 2.0


### What's in this PR?
Skip installation of Kubernetes and Container runtime if they are already installed (based on configuration)


### Why?
We don't want PKE to install Kubernetes and CR when they are already present.


### Additional context

This is far from a perfect solution, but gets us started. Later, it can be improved in a backward compatible way.