### PR TITLE
Fix unbundled CNI plugin and update kubernetes-cni package version

### DIFF
--- a/cmd/pke/app/util/linux/apt.go
+++ b/cmd/pke/app/util/linux/apt.go
@@ -125,23 +125,27 @@ func AptInstall(out io.Writer, packages []string) error {
 func mapAptPackageVersion(pkg, kubernetesVersion string) string {
 	switch pkg {
 	case kubeadm:
-		return "kubeadm=" + kubernetesVersion + "-00"
+		return "kubeadm=" + getAptPackageVersion(kubernetesVersion)
 
 	case kubectl:
-		return "kubectl=" + kubernetesVersion + "-00"
+		return "kubectl=" + getAptPackageVersion(kubernetesVersion)
 
 	case kubelet:
-		return "kubelet=" + kubernetesVersion + "-00"
+		return "kubelet=" + getAptPackageVersion(kubernetesVersion)
 
 	case kubernetescni:
-		ver, _ := semver.NewVersion(kubernetesVersion)
-		c, _ := semver.NewConstraint(">=1.15.0,<1.16.11 || >=1.17.0,<1.17.7 || >=1.18.0,<1.18.4")
-		if c.Check(ver) {
-			return "kubernetes-cni=0.7.5-00"
-		}
-		return ""
+		return "kubernetes-cni=0.8.6-00"
 
 	default:
 		return ""
 	}
+}
+
+func getAptPackageVersion(kubernetesVersion string) string {
+	ver, _ := semver.NewVersion(kubernetesVersion)
+	c, _ := semver.NewConstraint("=1.16.11 || =1.17.7 || =1.18.4")
+	if c.Check(ver) {
+		return kubernetesVersion + "-01"
+	}
+	return kubernetesVersion + "-00"
 }

--- a/cmd/pke/app/util/linux/apt.go
+++ b/cmd/pke/app/util/linux/apt.go
@@ -143,6 +143,7 @@ func mapAptPackageVersion(pkg, kubernetesVersion string) string {
 
 func getAptPackageVersion(kubernetesVersion string) string {
 	ver, _ := semver.NewVersion(kubernetesVersion)
+	// There was an issue with bundled CNI plugin so new package was released in case of versions below. (https://github.com/kubernetes/kubernetes/issues/92242)
 	c, _ := semver.NewConstraint("=1.16.11 || =1.17.7 || =1.18.4")
 	if c.Check(ver) {
 		return kubernetesVersion + "-01"

--- a/cmd/pke/app/util/linux/yum.go
+++ b/cmd/pke/app/util/linux/yum.go
@@ -184,11 +184,6 @@ func (y *YumInstaller) InstallKubernetesPackages(out io.Writer, kubernetesVersio
 		mapYumPackageVersion(kubernetescni, kubernetesVersion),
 		disableExcludesKubernetes,
 	}
-	ver, _ := semver.NewVersion(kubernetesVersion)
-	c, _ := semver.NewConstraint(">=1.15.0,<1.16.11 || >=1.17.0,<1.17.7 || >=1.18.0,<1.18.4")
-	if c.Check(ver) {
-		p = append(p, setopObsoletes)
-	}
 
 	return YumInstall(out, p)
 }
@@ -201,11 +196,7 @@ func (y *YumInstaller) InstallKubeadmPackage(out io.Writer, kubernetesVersion st
 		mapYumPackageVersion(kubernetescni, kubernetesVersion), // kubeadm dependency
 		disableExcludesKubernetes,
 	}
-	ver, _ := semver.NewVersion(kubernetesVersion)
-	c, _ := semver.NewConstraint(">=1.15.0,<1.16.11 || >=1.17.0,<1.17.7 || >=1.18.0,<1.18.4")
-	if c.Check(ver) {
-		pkg = append(pkg, setopObsoletes)
-	}
+
 	return YumInstall(out, pkg)
 }
 
@@ -221,23 +212,27 @@ func (y *YumInstaller) InstallContainerdPrerequisites(out io.Writer, containerdV
 func mapYumPackageVersion(pkg, kubernetesVersion string) string {
 	switch pkg {
 	case kubeadm:
-		return "kubeadm-" + kubernetesVersion + "-0"
+		return "kubeadm-" + getYumPackageVersion(kubernetesVersion)
 
 	case kubectl:
-		return "kubectl-" + kubernetesVersion + "-0"
+		return "kubectl-" + getYumPackageVersion(kubernetesVersion)
 
 	case kubelet:
-		return "kubelet-" + kubernetesVersion + "-0"
+		return "kubelet-" + getYumPackageVersion(kubernetesVersion)
 
 	case kubernetescni:
-		ver, _ := semver.NewVersion(kubernetesVersion)
-		c, _ := semver.NewConstraint(">=1.15.0,<1.16.11 || >=1.17.0,<1.17.7 || >=1.18.0,<1.18.4")
-		if c.Check(ver) {
-			return "kubernetes-cni-0.7.5-0"
-		}
-		return ""
+		return "kubernetes-cni-0.8.6-0"
 
 	default:
 		return ""
 	}
+}
+
+func getYumPackageVersion(kubernetesVersion string) string {
+	ver, _ := semver.NewVersion(kubernetesVersion)
+	c, _ := semver.NewConstraint("=1.16.11 || =1.17.7 || =1.18.4")
+	if c.Check(ver) {
+		return kubernetesVersion + "-1"
+	}
+	return kubernetesVersion + "-0"
 }

--- a/cmd/pke/app/util/linux/yum.go
+++ b/cmd/pke/app/util/linux/yum.go
@@ -36,7 +36,6 @@ const (
 	kubelet                   = "kubelet"
 	kubernetescni             = "kubernetes-cni"
 	disableExcludesKubernetes = "--disableexcludes=kubernetes"
-	setopObsoletes            = "--setopt=obsoletes=0"
 	selinuxConfig             = "/etc/selinux/config"
 	banzaiCloudRPMRepo        = "/etc/yum.repos.d/banzaicloud.repo"
 	k8sRPMRepoFile            = "/etc/yum.repos.d/kubernetes.repo"

--- a/cmd/pke/app/util/linux/yum.go
+++ b/cmd/pke/app/util/linux/yum.go
@@ -229,6 +229,7 @@ func mapYumPackageVersion(pkg, kubernetesVersion string) string {
 
 func getYumPackageVersion(kubernetesVersion string) string {
 	ver, _ := semver.NewVersion(kubernetesVersion)
+	// There was an issue with bundled CNI plugin so new package was released in case of versions below. (https://github.com/kubernetes/kubernetes/issues/92242)
 	c, _ := semver.NewConstraint("=1.16.11 || =1.17.7 || =1.18.4")
 	if c.Check(ver) {
 		return kubernetesVersion + "-1"

--- a/cmd/pke/app/util/linux/yum_test.go
+++ b/cmd/pke/app/util/linux/yum_test.go
@@ -26,11 +26,26 @@ func TestMapYumPackageVersion(t *testing.T) {
 		kubernetesVersion string
 		expected          string
 	}{
-		{kubeadm, "1.17.0", "kubeadm-1.17.0-0"},
-		{kubectl, "1.17.0", "kubectl-1.17.0-0"},
-		{kubelet, "1.17.0", "kubelet-1.17.0-0"},
-		{kubernetescni, "1.17.0", "kubernetes-cni-0.7.5-0"},
-		{kubernetescni, "1.18.4", ""},
+		{kubeadm, "1.16.10", "kubeadm-1.16.10-0"},
+		{kubectl, "1.16.10", "kubectl-1.16.10-0"},
+		{kubelet, "1.16.10", "kubelet-1.16.10-0"},
+		{kubeadm, "1.16.11", "kubeadm-1.16.11-1"},
+		{kubectl, "1.16.11", "kubectl-1.16.11-1"},
+		{kubelet, "1.16.11", "kubelet-1.16.11-1"},
+		{kubeadm, "1.17.6", "kubeadm-1.17.6-0"},
+		{kubectl, "1.17.6", "kubectl-1.17.6-0"},
+		{kubelet, "1.17.6", "kubelet-1.17.6-0"},
+		{kubeadm, "1.17.7", "kubeadm-1.17.7-1"},
+		{kubectl, "1.17.7", "kubectl-1.17.7-1"},
+		{kubelet, "1.17.7", "kubelet-1.17.7-1"},
+		{kubeadm, "1.18.3", "kubeadm-1.18.3-0"},
+		{kubectl, "1.18.3", "kubectl-1.18.3-0"},
+		{kubelet, "1.18.3", "kubelet-1.18.3-0"},
+		{kubeadm, "1.18.4", "kubeadm-1.18.4-1"},
+		{kubectl, "1.18.4", "kubectl-1.18.4-1"},
+		{kubelet, "1.18.4", "kubelet-1.18.4-1"},
+		{kubernetescni, "1.17.0", "kubernetes-cni-0.8.6-0"},
+		{kubernetescni, "1.18.4", "kubernetes-cni-0.8.6-0"},
 	}
 	for _, tc := range testCases {
 		got := mapYumPackageVersion(tc.pkg, tc.kubernetesVersion)
@@ -47,7 +62,7 @@ func TestParseRpmPackageOutput(t *testing.T) {
 		arch    string
 		err     bool
 	}{
-		{"kubernetes-cni-0.7.5-0.x86_64", "kubernetes-cni", "0.7.5", "0", "x86_64", false},
+		{"kubernetes-cni-0.8.6-0.x86_64", "kubernetes-cni", "0.8.6", "0", "x86_64", false},
 		{"kubeadm-1.18.0-0.x86_64", "kubeadm", "1.18.0", "0", "x86_64", false},
 		{"kubeadm", "", "", "", "", true},
 		{"util-linux-2.23.2-59.el7.x86_64", "util-linux", "2.23.2", "59.el7", "x86_64", false},


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/cloudinfo/pull/338
| License         | Apache 2.0


### What's in this PR?
- Use new kubernetes packages in case of 1.16.11, 1.17.7 and 1.18.4 due to fixed issue (https://github.com/kubernetes/kubernetes/issues/92242)
- Update kubernetes-cni package to 0.8.6
- Regression test is successfully completed with the new CNI package