### PR TITLE
fix(vagrant): CentOS 8 missing cilium requirement

### DIFF
--- a/Vagrantfile-centos8
+++ b/Vagrantfile-centos8
@@ -64,7 +64,8 @@ Vagrant.configure("2") do |config|
                 echo 'sync time'
                 systemctl enable --now chronyd
                 swapoff -a
-
+                modprobe ip_tables
+                echo 'ip_tables' >> /etc/modules-load.d/iptables.conf
                 echo 'set host name resolution'
                 cat >> /etc/hosts <<EOF
 192.168.64.11 centos1


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #124 
| License         | Apache 2.0


### What's in this PR?
Load missing `ip_tables` module by `Vagrantfile`.