### PR TITLE
Fix syntax errors in kubeadm config templates

### DIFF
--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta1.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta1.yaml.go
@@ -80,15 +80,15 @@ func kubeadmConfigV1Beta1Template() string {
 		"    terminated-pod-gc-threshold: \"10\"\n" +
 		"    feature-gates: \"RotateKubeletServerCertificate=true\"\n" +
 		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}cluster-signing-cert-file: {{ .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}{{end}}\n" +
-		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}\n" +
-		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}\n" +
+		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}\"\n" +
+		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}\"\n" +
 		"  extraVolumes:\n" +
 		"  {{range $k, $volume := .KubeadmConfig.ControllerManager.ExtraVolumes }}\n" +
 		"    - name: {{ $volume.Name }}\n" +
-		"\t    hostPath: {{ $volume.HostPath }}\n" +
-		"\t    mountPath: {{ $volume.MountPath }}\n" +
-		"\t    pathType: {{ $volume.PathType }}\n" +
-		"\t    readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}\n" +
+		"      hostPath: {{ $volume.HostPath }}\n" +
+		"      mountPath: {{ $volume.MountPath }}\n" +
+		"      pathType: {{ $volume.PathType }}\n" +
+		"      readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}\n" +
 		"etcd:\n" +
 		"  {{ if .KubeadmConfig.Etcd.External.Endpoints }}\n" +
 		"  external:\n" +

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta1.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta1.yaml.tmpl
@@ -62,15 +62,15 @@ controllerManager:
     terminated-pod-gc-threshold: "10"
     feature-gates: "RotateKubeletServerCertificate=true"
     {{ if .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}cluster-signing-cert-file: {{ .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}{{end}}
-    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}
-    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}
+    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}"
+    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}"
   extraVolumes:
   {{range $k, $volume := .KubeadmConfig.ControllerManager.ExtraVolumes }}
     - name: {{ $volume.Name }}
-	    hostPath: {{ $volume.HostPath }}
-	    mountPath: {{ $volume.MountPath }}
-	    pathType: {{ $volume.PathType }}
-	    readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}
+      hostPath: {{ $volume.HostPath }}
+      mountPath: {{ $volume.MountPath }}
+      pathType: {{ $volume.PathType }}
+      readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}
 etcd:
   {{ if .KubeadmConfig.Etcd.External.Endpoints }}
   external:

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta2.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta2.yaml.go
@@ -80,15 +80,15 @@ func kubeadmConfigV1Beta2Template() string {
 		"    terminated-pod-gc-threshold: \"10\"\n" +
 		"    feature-gates: \"RotateKubeletServerCertificate=true\"\n" +
 		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}cluster-signing-cert-file: {{ .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}{{end}}\n" +
-		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}\n" +
-		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}\n" +
+		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}\"\n" +
+		"    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: \"{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}\"\n" +
 		"  extraVolumes:\n" +
 		"  {{range $k, $volume := .KubeadmConfig.ControllerManager.ExtraVolumes }}\n" +
 		"    - name: {{ $volume.Name }}\n" +
-		"\t    hostPath: {{ $volume.HostPath }}\n" +
-		"\t    mountPath: {{ $volume.MountPath }}\n" +
-		"\t    pathType: {{ $volume.PathType }}\n" +
-		"\t    readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}\n" +
+		"      hostPath: {{ $volume.HostPath }}\n" +
+		"      mountPath: {{ $volume.MountPath }}\n" +
+		"      pathType: {{ $volume.PathType }}\n" +
+		"      readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}\n" +
 		"etcd:\n" +
 		"  {{ if .KubeadmConfig.Etcd.External.Endpoints }}\n" +
 		"  external:\n" +

--- a/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta2.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/upgrade/controlplane/kubeadm_v1beta2.yaml.tmpl
@@ -62,15 +62,15 @@ controllerManager:
     terminated-pod-gc-threshold: "10"
     feature-gates: "RotateKubeletServerCertificate=true"
     {{ if .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}cluster-signing-cert-file: {{ .KubeadmConfig.ControllerManager.ExtraArgs.ClusterSigningCertFile }}{{end}}
-    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}
-    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}
+    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}cloud-provider: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudProvider }}"
+    {{ if .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}cloud-config: "{{ .KubeadmConfig.ControllerManager.ExtraArgs.CloudConfig }}"
   extraVolumes:
   {{range $k, $volume := .KubeadmConfig.ControllerManager.ExtraVolumes }}
     - name: {{ $volume.Name }}
-	    hostPath: {{ $volume.HostPath }}
-	    mountPath: {{ $volume.MountPath }}
-	    pathType: {{ $volume.PathType }}
-	    readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}
+      hostPath: {{ $volume.HostPath }}
+      mountPath: {{ $volume.MountPath }}
+      pathType: {{ $volume.PathType }}
+      readOnly: {{ $volume.ReadOnly }}{{end}}{{end}}{{end}}
 etcd:
   {{ if .KubeadmConfig.Etcd.External.Endpoints }}
   external:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Fixes kubeadm config syntax errors


### Why?
`pke upgrade` failed on AWS
```
kubeadm [init phase upload-config kubeadm --config /etc/kubernetes/kubeadm-2020-11-11T12:23:33Z.conf]
  err> error converting YAML to JSON: yaml: line 75: found a tab character that violates indentation
  err> To see the stack trace of this error execute with --v=5 or higher
kubeadm [init phase upload-config kubeadm --config /etc/kubernetes/kubeadm-2020-11-11T12:23:33Z.conf] err: exit status 1 30.271223ms
Error: exit status 1
```


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
