### PR TITLE
Upgrade cilium to v1.9.0

### DIFF
--- a/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.go
@@ -17,7 +17,21 @@ package controlplane
 // ciliumTemplate is a generated function returning the template as a string.
 func ciliumTemplate() string {
 	var tmpl = "---\n" +
-		"# Source: cilium/charts/config/templates/configmap.yaml\n" +
+		"# Source: cilium/templates/cilium-agent-serviceaccount.yaml\n" +
+		"apiVersion: v1\n" +
+		"kind: ServiceAccount\n" +
+		"metadata:\n" +
+		"  name: cilium\n" +
+		"  namespace: kube-system\n" +
+		"---\n" +
+		"# Source: cilium/templates/cilium-operator-serviceaccount.yaml\n" +
+		"apiVersion: v1\n" +
+		"kind: ServiceAccount\n" +
+		"metadata:\n" +
+		"  name: cilium-operator\n" +
+		"  namespace: kube-system\n" +
+		"---\n" +
+		"# Source: cilium/templates/cilium-configmap.yaml\n" +
 		"apiVersion: v1\n" +
 		"kind: ConfigMap\n" +
 		"metadata:\n" +
@@ -36,6 +50,7 @@ func ciliumTemplate() string {
 		"  #   the kvstore by commenting out the identity-allocation-mode below, or\n" +
 		"  #   setting it to \"kvstore\".\n" +
 		"  identity-allocation-mode: crd\n" +
+		"  cilium-endpoint-gc-interval: \"5m0s\"\n" +
 		"\n" +
 		"  # If you want to run cilium in debug mode change this value to true\n" +
 		"  debug: \"false\"\n" +
@@ -47,26 +62,35 @@ func ciliumTemplate() string {
 		"  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6\n" +
 		"  # address.\n" +
 		"  enable-ipv6: \"false\"\n" +
-		"\n" +
+		"  # Users who wish to specify their own custom CNI configuration file must set\n" +
+		"  # custom-cni-conf to \"true\", otherwise Cilium may overwrite the configuration.\n" +
+		"  custom-cni-conf: \"false\"\n" +
+		"  enable-bpf-clock-probe: \"true\"\n" +
 		"  # If you want cilium monitor to aggregate tracing for packets, set this level\n" +
 		"  # to \"low\", \"medium\", or \"maximum\". The higher the level, the less packets\n" +
 		"  # that will be seen in monitor output.\n" +
 		"  monitor-aggregation: medium\n" +
 		"\n" +
-		"  # ct-global-max-entries-* specifies the maximum number of connections\n" +
-		"  # supported across all endpoints, split by protocol: tcp or other. One pair\n" +
-		"  # of maps uses these values for IPv4 connections, and another pair of maps\n" +
-		"  # use these values for IPv6 connections.\n" +
+		"  # The monitor aggregation interval governs the typical time between monitor\n" +
+		"  # notification events for each allowed connection.\n" +
 		"  #\n" +
-		"  # If these values are modified, then during the next Cilium startup the\n" +
-		"  # tracking of ongoing connections may be disrupted. This may lead to brief\n" +
-		"  # policy drops or a change in loadbalancing decisions for a connection.\n" +
-		"  #\n" +
-		"  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption\n" +
-		"  # during the upgrade process, comment out these options.\n" +
-		"  bpf-ct-global-tcp-max: \"524288\"\n" +
-		"  bpf-ct-global-any-max: \"262144\"\n" +
+		"  # Only effective when monitor aggregation is set to \"medium\" or higher.\n" +
+		"  monitor-aggregation-interval: 5s\n" +
 		"\n" +
+		"  # The monitor aggregation flags determine which TCP flags which, upon the\n" +
+		"  # first observation, cause monitor notifications to be generated.\n" +
+		"  #\n" +
+		"  # Only effective when monitor aggregation is set to \"medium\" or higher.\n" +
+		"  monitor-aggregation-flags: all\n" +
+		"  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic\n" +
+		"  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.\n" +
+		"  bpf-map-dynamic-size-ratio: \"0.0025\"\n" +
+		"  # bpf-policy-map-max specifies the maximum number of entries in endpoint\n" +
+		"  # policy map (per endpoint)\n" +
+		"  bpf-policy-map-max: \"16384\"\n" +
+		"  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,\n" +
+		"  # backend and affinity maps.\n" +
+		"  bpf-lb-map-max: \"65536\"\n" +
 		"  # Pre-allocation of map entries allows per-packet latency to be reduced, at\n" +
 		"  # the expense of up-front memory allocation for the entries in the maps. The\n" +
 		"  # default value below will minimize memory usage in the default installation;\n" +
@@ -77,9 +101,8 @@ func ciliumTemplate() string {
 		"  #\n" +
 		"  # If this value is modified, then during the next Cilium startup the restore\n" +
 		"  # of existing endpoints and tracking of ongoing connections may be disrupted.\n" +
-		"  # This may lead to policy drops or a change in loadbalancing decisions for a\n" +
-		"  # connection for some time. Endpoints may need to be recreated to restore\n" +
-		"  # connectivity.\n" +
+		"  # As a result, reply packets may be dropped and the load-balancing decisions\n" +
+		"  # for established connections may change.\n" +
 		"  #\n" +
 		"  # If this option is set to \"false\" during an upgrade from 1.3 or earlier to\n" +
 		"  # 1.4 or later, then it may cause one-time disruptions during the upgrade.\n" +
@@ -98,76 +121,42 @@ func ciliumTemplate() string {
 		"\n" +
 		"  # Name of the cluster. Only relevant when building a mesh of clusters.\n" +
 		"  cluster-name: default\n" +
-		"\n" +
-		"  # DNS Polling periodically issues a DNS lookup for each `matchName` from\n" +
-		"  # cilium-agent. The result is used to regenerate endpoint policy.\n" +
-		"  # DNS lookups are repeated with an interval of 5 seconds, and are made for\n" +
-		"  # A(IPv4) and AAAA(IPv6) addresses. Should a lookup fail, the most recent IP\n" +
-		"  # data is used instead. An IP change will trigger a regeneration of the Cilium\n" +
-		"  # policy for each endpoint and increment the per cilium-agent policy\n" +
-		"  # repository revision.\n" +
-		"  #\n" +
-		"  # This option is disabled by default starting from version 1.4.x in favor\n" +
-		"  # of a more powerful DNS proxy-based implementation, see [0] for details.\n" +
-		"  # Enable this option if you want to use FQDN policies but do not want to use\n" +
-		"  # the DNS proxy.\n" +
-		"  #\n" +
-		"  # To ease upgrade, users may opt to set this option to \"true\".\n" +
-		"  # Otherwise please refer to the Upgrade Guide [1] which explains how to\n" +
-		"  # prepare policy rules for upgrade.\n" +
-		"  #\n" +
-		"  # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based\n" +
-		"  # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action\n" +
-		"  tofqdns-enable-poller: \"false\"\n" +
+		"  # Enables L7 proxy for L7 policy enforcement and visibility\n" +
+		"  enable-l7-proxy: \"true\"\n" +
 		"\n" +
 		"  # wait-bpf-mount makes init container wait until bpf filesystem is mounted\n" +
 		"  wait-bpf-mount: \"false\"\n" +
 		"\n" +
-		"  # Enable fetching of container-runtime specific metadata\n" +
-		"  #\n" +
-		"  # By default, the Kubernetes pod and namespace labels are retrieved and\n" +
-		"  # associated with endpoints for identification purposes. By integrating\n" +
-		"  # with the container runtime, container runtime specific labels can be\n" +
-		"  # retrieved, such labels will be prefixed with container:\n" +
-		"  #\n" +
-		"  # CAUTION: The container runtime labels can include information such as pod\n" +
-		"  # annotations which may result in each pod being associated a unique set of\n" +
-		"  # labels which can result in excessive security identities being allocated.\n" +
-		"  # Please review the labels filter when enabling container runtime labels.\n" +
-		"  #\n" +
-		"  # Supported values:\n" +
-		"  # - containerd\n" +
-		"  # - crio\n" +
-		"  # - docker\n" +
-		"  # - none\n" +
-		"  # - auto (automatically detect the container runtime)\n" +
-		"  #\n" +
-		"  container-runtime: none\n" +
-		"\n" +
 		"  masquerade: \"true\"\n" +
+		"  enable-bpf-masquerade: \"true\"\n" +
 		"\n" +
+		"  enable-xt-socket-fallback: \"true\"\n" +
 		"  install-iptables-rules: \"true\"\n" +
+		"\n" +
 		"  auto-direct-node-routes: \"false\"\n" +
-		"  enable-node-port: \"false\"\n" +
-		"\n" +
+		"  enable-bandwidth-manager: \"false\"\n" +
+		"  enable-local-redirect-policy: \"false\"\n" +
+		"  kube-proxy-replacement:  \"probe\"\n" +
+		"  kube-proxy-replacement-healthz-bind-address: \"\"\n" +
+		"  enable-health-check-nodeport: \"true\"\n" +
+		"  node-port-bind-protection: \"true\"\n" +
+		"  enable-auto-protect-node-port-range: \"true\"\n" +
+		"  enable-session-affinity: \"true\"\n" +
+		"  enable-endpoint-health-checking: \"true\"\n" +
+		"  enable-health-checking: \"true\"\n" +
+		"  enable-well-known-identities: \"false\"\n" +
+		"  enable-remote-node-identity: \"true\"\n" +
+		"  operator-api-serve-addr: \"127.0.0.1:9234\"\n" +
+		"  # Enable Hubble gRPC service.\n" +
+		"  enable-hubble: \"true\"\n" +
+		"  # UNIX domain socket for Hubble server to listen to.\n" +
+		"  hubble-socket-path:  \"/var/run/cilium/hubble.sock\"\n" +
+		"  ipam: \"cluster-pool\"\n" +
+		"  cluster-pool-ipv4-cidr: \"10.0.0.0/8\"\n" +
+		"  cluster-pool-ipv4-mask-size: \"24\"\n" +
+		"  disable-cnp-status-updates: \"true\"\n" +
 		"---\n" +
-		"# Source: cilium/charts/agent/templates/serviceaccount.yaml\n" +
-		"apiVersion: v1\n" +
-		"kind: ServiceAccount\n" +
-		"metadata:\n" +
-		"  name: cilium\n" +
-		"  namespace: kube-system\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/operator/templates/serviceaccount.yaml\n" +
-		"apiVersion: v1\n" +
-		"kind: ServiceAccount\n" +
-		"metadata:\n" +
-		"  name: cilium-operator\n" +
-		"  namespace: kube-system\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/agent/templates/clusterrole.yaml\n" +
+		"# Source: cilium/templates/cilium-agent-clusterrole.yaml\n" +
 		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRole\n" +
 		"metadata:\n" +
@@ -177,6 +166,14 @@ func ciliumTemplate() string {
 		"  - networking.k8s.io\n" +
 		"  resources:\n" +
 		"  - networkpolicies\n" +
+		"  verbs:\n" +
+		"  - get\n" +
+		"  - list\n" +
+		"  - watch\n" +
+		"- apiGroups:\n" +
+		"  - discovery.k8s.io\n" +
+		"  resources:\n" +
+		"  - endpointslices\n" +
 		"  verbs:\n" +
 		"  - get\n" +
 		"  - list\n" +
@@ -196,6 +193,16 @@ func ciliumTemplate() string {
 		"  - \"\"\n" +
 		"  resources:\n" +
 		"  - pods\n" +
+		"  - pods/finalizers\n" +
+		"  verbs:\n" +
+		"  - get\n" +
+		"  - list\n" +
+		"  - watch\n" +
+		"  - update\n" +
+		"  - delete\n" +
+		"- apiGroups:\n" +
+		"  - \"\"\n" +
+		"  resources:\n" +
 		"  - nodes\n" +
 		"  verbs:\n" +
 		"  - get\n" +
@@ -210,40 +217,44 @@ func ciliumTemplate() string {
 		"  verbs:\n" +
 		"  - patch\n" +
 		"- apiGroups:\n" +
-		"  - extensions\n" +
-		"  resources:\n" +
-		"  - ingresses\n" +
-		"  verbs:\n" +
-		"  - create\n" +
-		"  - get\n" +
-		"  - list\n" +
-		"  - watch\n" +
-		"- apiGroups:\n" +
 		"  - apiextensions.k8s.io\n" +
 		"  resources:\n" +
 		"  - customresourcedefinitions\n" +
 		"  verbs:\n" +
+		"  # Deprecated for removal in v1.10\n" +
 		"  - create\n" +
-		"  - get\n" +
 		"  - list\n" +
 		"  - watch\n" +
 		"  - update\n" +
+		"\n" +
+		"  # This is used when validating policies in preflight. This will need to stay\n" +
+		"  # until we figure out how to avoid \"get\" inside the preflight, and then\n" +
+		"  # should be removed ideally.\n" +
+		"  - get\n" +
 		"- apiGroups:\n" +
 		"  - cilium.io\n" +
 		"  resources:\n" +
 		"  - ciliumnetworkpolicies\n" +
 		"  - ciliumnetworkpolicies/status\n" +
+		"  - ciliumnetworkpolicies/finalizers\n" +
+		"  - ciliumclusterwidenetworkpolicies\n" +
+		"  - ciliumclusterwidenetworkpolicies/status\n" +
+		"  - ciliumclusterwidenetworkpolicies/finalizers\n" +
 		"  - ciliumendpoints\n" +
 		"  - ciliumendpoints/status\n" +
+		"  - ciliumendpoints/finalizers\n" +
 		"  - ciliumnodes\n" +
 		"  - ciliumnodes/status\n" +
+		"  - ciliumnodes/finalizers\n" +
 		"  - ciliumidentities\n" +
-		"  - ciliumidentities/status\n" +
+		"  - ciliumidentities/finalizers\n" +
+		"  - ciliumlocalredirectpolicies\n" +
+		"  - ciliumlocalredirectpolicies/status\n" +
+		"  - ciliumlocalredirectpolicies/finalizers\n" +
 		"  verbs:\n" +
 		"  - '*'\n" +
-		"\n" +
 		"---\n" +
-		"# Source: cilium/charts/operator/templates/clusterrole.yaml\n" +
+		"# Source: cilium/templates/cilium-operator-clusterrole.yaml\n" +
 		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRole\n" +
 		"metadata:\n" +
@@ -261,12 +272,16 @@ func ciliumTemplate() string {
 		"  - watch\n" +
 		"  - delete\n" +
 		"- apiGroups:\n" +
+		"  - discovery.k8s.io\n" +
+		"  resources:\n" +
+		"  - endpointslices\n" +
+		"  verbs:\n" +
+		"  - get\n" +
+		"  - list\n" +
+		"  - watch\n" +
+		"- apiGroups:\n" +
 		"  - \"\"\n" +
 		"  resources:\n" +
-		"  # to automatically read from k8s and import the node's pod CIDR to cilium's\n" +
-		"  # etcd so all nodes know how to reach another pod running in in a different\n" +
-		"  # node.\n" +
-		"  - nodes\n" +
 		"  # to perform the translation of a CNP that contains `ToGroup` to its endpoints\n" +
 		"  - services\n" +
 		"  - endpoints\n" +
@@ -281,17 +296,53 @@ func ciliumTemplate() string {
 		"  resources:\n" +
 		"  - ciliumnetworkpolicies\n" +
 		"  - ciliumnetworkpolicies/status\n" +
+		"  - ciliumnetworkpolicies/finalizers\n" +
+		"  - ciliumclusterwidenetworkpolicies\n" +
+		"  - ciliumclusterwidenetworkpolicies/status\n" +
+		"  - ciliumclusterwidenetworkpolicies/finalizers\n" +
 		"  - ciliumendpoints\n" +
 		"  - ciliumendpoints/status\n" +
+		"  - ciliumendpoints/finalizers\n" +
 		"  - ciliumnodes\n" +
 		"  - ciliumnodes/status\n" +
+		"  - ciliumnodes/finalizers\n" +
 		"  - ciliumidentities\n" +
 		"  - ciliumidentities/status\n" +
+		"  - ciliumidentities/finalizers\n" +
+		"  - ciliumlocalredirectpolicies\n" +
+		"  - ciliumlocalredirectpolicies/status\n" +
+		"  - ciliumlocalredirectpolicies/finalizers\n" +
 		"  verbs:\n" +
 		"  - '*'\n" +
-		"\n" +
+		"- apiGroups:\n" +
+		"  - apiextensions.k8s.io\n" +
+		"  resources:\n" +
+		"  - customresourcedefinitions\n" +
+		"  verbs:\n" +
+		"  - create\n" +
+		"  - get\n" +
+		"  - list\n" +
+		"  - update\n" +
+		"  - watch\n" +
+		"# For cilium-operator running in HA mode.\n" +
+		"#\n" +
+		"# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election\n" +
+		"# between mulitple running instances.\n" +
+		"# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less\n" +
+		"# common and fewer objects in the cluster watch \"all Leases\".\n" +
+		"# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.\n" +
+		"# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure\n" +
+		"# that we only authorize access to leases resources in supported K8s versions.\n" +
+		"- apiGroups:\n" +
+		"  - coordination.k8s.io\n" +
+		"  resources:\n" +
+		"  - leases\n" +
+		"  verbs:\n" +
+		"  - create\n" +
+		"  - get\n" +
+		"  - update\n" +
 		"---\n" +
-		"# Source: cilium/charts/agent/templates/clusterrolebinding.yaml\n" +
+		"# Source: cilium/templates/cilium-agent-clusterrolebinding.yaml\n" +
 		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRoleBinding\n" +
 		"metadata:\n" +
@@ -304,9 +355,8 @@ func ciliumTemplate() string {
 		"- kind: ServiceAccount\n" +
 		"  name: cilium\n" +
 		"  namespace: kube-system\n" +
-		"\n" +
 		"---\n" +
-		"# Source: cilium/charts/operator/templates/clusterrolebinding.yaml\n" +
+		"# Source: cilium/templates/cilium-operator-clusterrolebinding.yaml\n" +
 		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRoleBinding\n" +
 		"metadata:\n" +
@@ -319,22 +369,23 @@ func ciliumTemplate() string {
 		"- kind: ServiceAccount\n" +
 		"  name: cilium-operator\n" +
 		"  namespace: kube-system\n" +
-		"\n" +
 		"---\n" +
-		"# Source: cilium/charts/agent/templates/daemonset.yaml\n" +
+		"# Source: cilium/templates/cilium-agent-daemonset.yaml\n" +
 		"apiVersion: apps/v1\n" +
 		"kind: DaemonSet\n" +
 		"metadata:\n" +
 		"  labels:\n" +
 		"    k8s-app: cilium\n" +
-		"    kubernetes.io/cluster-service: \"true\"\n" +
 		"  name: cilium\n" +
 		"  namespace: kube-system\n" +
 		"spec:\n" +
 		"  selector:\n" +
 		"    matchLabels:\n" +
 		"      k8s-app: cilium\n" +
-		"      kubernetes.io/cluster-service: \"true\"\n" +
+		"  updateStrategy:\n" +
+		"    rollingUpdate:\n" +
+		"      maxUnavailable: 2\n" +
+		"    type: RollingUpdate\n" +
 		"  template:\n" +
 		"    metadata:\n" +
 		"      annotations:\n" +
@@ -343,16 +394,55 @@ func ciliumTemplate() string {
 		"        # gets priority scheduling.\n" +
 		"        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/\n" +
 		"        scheduler.alpha.kubernetes.io/critical-pod: \"\"\n" +
-		"        scheduler.alpha.kubernetes.io/tolerations: '[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"master\",\"effect\":\"NoSchedule\"}]'\n" +
 		"      labels:\n" +
 		"        k8s-app: cilium\n" +
-		"        kubernetes.io/cluster-service: \"true\"\n" +
 		"    spec:\n" +
+		"      affinity:\n" +
+		"        podAntiAffinity:\n" +
+		"          requiredDuringSchedulingIgnoredDuringExecution:\n" +
+		"          - labelSelector:\n" +
+		"              matchExpressions:\n" +
+		"              - key: k8s-app\n" +
+		"                operator: In\n" +
+		"                values:\n" +
+		"                - cilium\n" +
+		"            topologyKey: kubernetes.io/hostname\n" +
 		"      containers:\n" +
 		"      - args:\n" +
 		"        - --config-dir=/tmp/cilium/config-map\n" +
 		"        command:\n" +
 		"        - cilium-agent\n" +
+		"        livenessProbe:\n" +
+		"          httpGet:\n" +
+		"            host: '127.0.0.1'\n" +
+		"            path: /healthz\n" +
+		"            port: 9876\n" +
+		"            scheme: HTTP\n" +
+		"            httpHeaders:\n" +
+		"            - name: \"brief\"\n" +
+		"              value: \"true\"\n" +
+		"          failureThreshold: 10\n" +
+		"          # The initial delay for the liveness probe is intentionally large to\n" +
+		"          # avoid an endless kill & restart cycle if in the event that the initial\n" +
+		"          # bootstrapping takes longer than expected.\n" +
+		"          initialDelaySeconds: 120\n" +
+		"          periodSeconds: 30\n" +
+		"          successThreshold: 1\n" +
+		"          timeoutSeconds: 5\n" +
+		"        readinessProbe:\n" +
+		"          httpGet:\n" +
+		"            host: '127.0.0.1'\n" +
+		"            path: /healthz\n" +
+		"            port: 9876\n" +
+		"            scheme: HTTP\n" +
+		"            httpHeaders:\n" +
+		"            - name: \"brief\"\n" +
+		"              value: \"true\"\n" +
+		"          failureThreshold: 3\n" +
+		"          initialDelaySeconds: 5\n" +
+		"          periodSeconds: 30\n" +
+		"          successThreshold: 1\n" +
+		"          timeoutSeconds: 5\n" +
 		"        env:\n" +
 		"        - name: K8S_NODE_NAME\n" +
 		"          valueFrom:\n" +
@@ -390,43 +480,19 @@ func ciliumTemplate() string {
 		"              key: custom-cni-conf\n" +
 		"              name: cilium-config\n" +
 		"              optional: true\n" +
-		"        image: \"{{ .ImageRepository }}/cilium:v1.6.4\"\n" +
+		"        image: quay.io/cilium/cilium:v1.9.0\n" +
 		"        imagePullPolicy: IfNotPresent\n" +
 		"        lifecycle:\n" +
 		"          postStart:\n" +
 		"            exec:\n" +
 		"              command:\n" +
-		"              - /cni-install.sh\n" +
+		"              - \"/cni-install.sh\"\n" +
+		"              - \"--enable-debug=false\"\n" +
 		"          preStop:\n" +
 		"            exec:\n" +
 		"              command:\n" +
 		"              - /cni-uninstall.sh\n" +
-		"        livenessProbe:\n" +
-		"          exec:\n" +
-		"            command:\n" +
-		"            - cilium\n" +
-		"            - status\n" +
-		"            - --brief\n" +
-		"          failureThreshold: 10\n" +
-		"          # The initial delay for the liveness probe is intentionally large to\n" +
-		"          # avoid an endless kill & restart cycle if in the event that the initial\n" +
-		"          # bootstrapping takes longer than expected.\n" +
-		"          initialDelaySeconds: 120\n" +
-		"          periodSeconds: 30\n" +
-		"          successThreshold: 1\n" +
-		"          timeoutSeconds: 5\n" +
 		"        name: cilium-agent\n" +
-		"        readinessProbe:\n" +
-		"          exec:\n" +
-		"            command:\n" +
-		"            - cilium\n" +
-		"            - status\n" +
-		"            - --brief\n" +
-		"          failureThreshold: 3\n" +
-		"          initialDelaySeconds: 5\n" +
-		"          periodSeconds: 30\n" +
-		"          successThreshold: 1\n" +
-		"          timeoutSeconds: 5\n" +
 		"        securityContext:\n" +
 		"          capabilities:\n" +
 		"            add:\n" +
@@ -477,7 +543,7 @@ func ciliumTemplate() string {
 		"              key: wait-bpf-mount\n" +
 		"              name: cilium-config\n" +
 		"              optional: true\n" +
-		"        image: \"{{ .ImageRepository }}/cilium:v1.6.4\"\n" +
+		"        image: quay.io/cilium/cilium:v1.9.0\n" +
 		"        imagePullPolicy: IfNotPresent\n" +
 		"        name: clean-cilium-state\n" +
 		"        securityContext:\n" +
@@ -488,9 +554,15 @@ func ciliumTemplate() string {
 		"        volumeMounts:\n" +
 		"        - mountPath: /sys/fs/bpf\n" +
 		"          name: bpf-maps\n" +
+		"          mountPropagation: HostToContainer\n" +
 		"        - mountPath: /var/run/cilium\n" +
 		"          name: cilium-run\n" +
+		"        resources:\n" +
+		"          requests:\n" +
+		"            cpu: 100m\n" +
+		"            memory: 100Mi\n" +
 		"      restartPolicy: Always\n" +
+		"      priorityClassName: system-node-critical\n" +
 		"      serviceAccount: cilium\n" +
 		"      serviceAccountName: cilium\n" +
 		"      terminationGracePeriodSeconds: 1\n" +
@@ -536,13 +608,8 @@ func ciliumTemplate() string {
 		"      - configMap:\n" +
 		"          name: cilium-config\n" +
 		"        name: cilium-config-path\n" +
-		"  updateStrategy:\n" +
-		"    rollingUpdate:\n" +
-		"      maxUnavailable: 2\n" +
-		"    type: RollingUpdate\n" +
-		"\n" +
 		"---\n" +
-		"# Source: cilium/charts/operator/templates/deployment.yaml\n" +
+		"# Source: cilium/templates/cilium-operator-deployment.yaml\n" +
 		"apiVersion: apps/v1\n" +
 		"kind: Deployment\n" +
 		"metadata:\n" +
@@ -552,7 +619,10 @@ func ciliumTemplate() string {
 		"  name: cilium-operator\n" +
 		"  namespace: kube-system\n" +
 		"spec:\n" +
-		"  replicas: 1\n" +
+		"  # We support HA mode only for Kubernetes version > 1.14\n" +
+		"  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go\n" +
+		"  # for more details.\n" +
+		"  replicas: 2\n" +
 		"  selector:\n" +
 		"    matchLabels:\n" +
 		"      io.cilium/app: operator\n" +
@@ -569,117 +639,69 @@ func ciliumTemplate() string {
 		"        io.cilium/app: operator\n" +
 		"        name: cilium-operator\n" +
 		"    spec:\n" +
+		"      # In HA mode, cilium-operator pods must not be scheduled on the same\n" +
+		"      # node as they will clash with each other.\n" +
+		"      affinity:\n" +
+		"        podAntiAffinity:\n" +
+		"          requiredDuringSchedulingIgnoredDuringExecution:\n" +
+		"          - labelSelector:\n" +
+		"              matchExpressions:\n" +
+		"              - key: io.cilium/app\n" +
+		"                operator: In\n" +
+		"                values:\n" +
+		"                - operator\n" +
+		"            topologyKey: kubernetes.io/hostname\n" +
 		"      containers:\n" +
 		"      - args:\n" +
+		"        - --config-dir=/tmp/cilium/config-map\n" +
 		"        - --debug=$(CILIUM_DEBUG)\n" +
-		"        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)\n" +
 		"        command:\n" +
-		"        - cilium-operator\n" +
+		"        - cilium-operator-generic\n" +
 		"        env:\n" +
-		"        - name: CILIUM_K8S_NAMESPACE\n" +
-		"          valueFrom:\n" +
-		"            fieldRef:\n" +
-		"              apiVersion: v1\n" +
-		"              fieldPath: metadata.namespace\n" +
 		"        - name: K8S_NODE_NAME\n" +
 		"          valueFrom:\n" +
 		"            fieldRef:\n" +
 		"              apiVersion: v1\n" +
 		"              fieldPath: spec.nodeName\n" +
+		"        - name: CILIUM_K8S_NAMESPACE\n" +
+		"          valueFrom:\n" +
+		"            fieldRef:\n" +
+		"              apiVersion: v1\n" +
+		"              fieldPath: metadata.namespace\n" +
 		"        - name: CILIUM_DEBUG\n" +
 		"          valueFrom:\n" +
 		"            configMapKeyRef:\n" +
 		"              key: debug\n" +
 		"              name: cilium-config\n" +
 		"              optional: true\n" +
-		"        - name: CILIUM_CLUSTER_NAME\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: cluster-name\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_CLUSTER_ID\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: cluster-id\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_IPAM\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: ipam\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_DISABLE_ENDPOINT_CRD\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: disable-endpoint-crd\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_KVSTORE\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: kvstore\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_KVSTORE_OPT\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: kvstore-opt\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        - name: AWS_ACCESS_KEY_ID\n" +
-		"          valueFrom:\n" +
-		"            secretKeyRef:\n" +
-		"              key: AWS_ACCESS_KEY_ID\n" +
-		"              name: cilium-aws\n" +
-		"              optional: true\n" +
-		"        - name: AWS_SECRET_ACCESS_KEY\n" +
-		"          valueFrom:\n" +
-		"            secretKeyRef:\n" +
-		"              key: AWS_SECRET_ACCESS_KEY\n" +
-		"              name: cilium-aws\n" +
-		"              optional: true\n" +
-		"        - name: AWS_DEFAULT_REGION\n" +
-		"          valueFrom:\n" +
-		"            secretKeyRef:\n" +
-		"              key: AWS_DEFAULT_REGION\n" +
-		"              name: cilium-aws\n" +
-		"              optional: true\n" +
-		"        - name: CILIUM_IDENTITY_ALLOCATION_MODE\n" +
-		"          valueFrom:\n" +
-		"            configMapKeyRef:\n" +
-		"              key: identity-allocation-mode\n" +
-		"              name: cilium-config\n" +
-		"              optional: true\n" +
-		"        image: \"{{ .ImageRepository }}/cilium-operator:v1.6.4\"\n" +
+		"        image: quay.io/cilium/operator-generic:v1.9.0\n" +
 		"        imagePullPolicy: IfNotPresent\n" +
 		"        name: cilium-operator\n" +
 		"        livenessProbe:\n" +
 		"          httpGet:\n" +
+		"            host: '127.0.0.1'\n" +
 		"            path: /healthz\n" +
 		"            port: 9234\n" +
 		"            scheme: HTTP\n" +
 		"          initialDelaySeconds: 60\n" +
 		"          periodSeconds: 10\n" +
 		"          timeoutSeconds: 3\n" +
-		"\n" +
+		"        volumeMounts:\n" +
+		"        - mountPath: /tmp/cilium/config-map\n" +
+		"          name: cilium-config-path\n" +
+		"          readOnly: true\n" +
 		"      hostNetwork: true\n" +
 		"      restartPolicy: Always\n" +
+		"      priorityClassName: system-cluster-critical\n" +
 		"      serviceAccount: cilium-operator\n" +
 		"      serviceAccountName: cilium-operator\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/agent/templates/servicemonitor.yaml\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/agent/templates/svc.yaml\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/operator/templates/servicemonitor.yaml\n" +
-		"\n" +
-		"---\n" +
-		"# Source: cilium/charts/operator/templates/svc.yaml\n" +
+		"      tolerations:\n" +
+		"      - operator: Exists\n" +
+		"      volumes:\n" +
+		"        # To read the configuration from the config map\n" +
+		"      - configMap:\n" +
+		"          name: cilium-config\n" +
+		"        name: cilium-config-path\n" +
 		""
 	return tmpl
 }

--- a/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.tmpl
@@ -1,5 +1,19 @@
 ---
-# Source: cilium/charts/config/templates/configmap.yaml
+# Source: cilium/templates/cilium-agent-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,6 +32,7 @@ data:
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
   identity-allocation-mode: crd
+  cilium-endpoint-gc-interval: "5m0s"
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -29,26 +44,35 @@ data:
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
   enable-ipv6: "false"
-
+  # Users who wish to specify their own custom CNI configuration file must set
+  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
+  custom-cni-conf: "false"
+  enable-bpf-clock-probe: "true"
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.
   monitor-aggregation: medium
 
-  # ct-global-max-entries-* specifies the maximum number of connections
-  # supported across all endpoints, split by protocol: tcp or other. One pair
-  # of maps uses these values for IPv4 connections, and another pair of maps
-  # use these values for IPv6 connections.
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
   #
-  # If these values are modified, then during the next Cilium startup the
-  # tracking of ongoing connections may be disrupted. This may lead to brief
-  # policy drops or a change in loadbalancing decisions for a connection.
-  #
-  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
-  # during the upgrade process, comment out these options.
-  bpf-ct-global-tcp-max: "524288"
-  bpf-ct-global-any-max: "262144"
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: 5s
 
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: all
+  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "0.0025"
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "65536"
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;
@@ -59,9 +83,8 @@ data:
   #
   # If this value is modified, then during the next Cilium startup the restore
   # of existing endpoints and tracking of ongoing connections may be disrupted.
-  # This may lead to policy drops or a change in loadbalancing decisions for a
-  # connection for some time. Endpoints may need to be recreated to restore
-  # connectivity.
+  # As a result, reply packets may be dropped and the load-balancing decisions
+  # for established connections may change.
   #
   # If this option is set to "false" during an upgrade from 1.3 or earlier to
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
@@ -80,76 +103,42 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
-
-  # DNS Polling periodically issues a DNS lookup for each `matchName` from
-  # cilium-agent. The result is used to regenerate endpoint policy.
-  # DNS lookups are repeated with an interval of 5 seconds, and are made for
-  # A(IPv4) and AAAA(IPv6) addresses. Should a lookup fail, the most recent IP
-  # data is used instead. An IP change will trigger a regeneration of the Cilium
-  # policy for each endpoint and increment the per cilium-agent policy
-  # repository revision.
-  #
-  # This option is disabled by default starting from version 1.4.x in favor
-  # of a more powerful DNS proxy-based implementation, see [0] for details.
-  # Enable this option if you want to use FQDN policies but do not want to use
-  # the DNS proxy.
-  #
-  # To ease upgrade, users may opt to set this option to "true".
-  # Otherwise please refer to the Upgrade Guide [1] which explains how to
-  # prepare policy rules for upgrade.
-  #
-  # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
-  # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
-  tofqdns-enable-poller: "false"
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  enable-l7-proxy: "true"
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
 
-  # Enable fetching of container-runtime specific metadata
-  #
-  # By default, the Kubernetes pod and namespace labels are retrieved and
-  # associated with endpoints for identification purposes. By integrating
-  # with the container runtime, container runtime specific labels can be
-  # retrieved, such labels will be prefixed with container:
-  #
-  # CAUTION: The container runtime labels can include information such as pod
-  # annotations which may result in each pod being associated a unique set of
-  # labels which can result in excessive security identities being allocated.
-  # Please review the labels filter when enabling container runtime labels.
-  #
-  # Supported values:
-  # - containerd
-  # - crio
-  # - docker
-  # - none
-  # - auto (automatically detect the container runtime)
-  #
-  container-runtime: none
-
   masquerade: "true"
+  enable-bpf-masquerade: "true"
 
+  enable-xt-socket-fallback: "true"
   install-iptables-rules: "true"
+
   auto-direct-node-routes: "false"
-  enable-node-port: "false"
-
+  enable-bandwidth-manager: "false"
+  enable-local-redirect-policy: "false"
+  kube-proxy-replacement:  "probe"
+  kube-proxy-replacement-healthz-bind-address: ""
+  enable-health-check-nodeport: "true"
+  node-port-bind-protection: "true"
+  enable-auto-protect-node-port-range: "true"
+  enable-session-affinity: "true"
+  enable-endpoint-health-checking: "true"
+  enable-health-checking: "true"
+  enable-well-known-identities: "false"
+  enable-remote-node-identity: "true"
+  operator-api-serve-addr: "127.0.0.1:9234"
+  # Enable Hubble gRPC service.
+  enable-hubble: "true"
+  # UNIX domain socket for Hubble server to listen to.
+  hubble-socket-path:  "/var/run/cilium/hubble.sock"
+  ipam: "cluster-pool"
+  cluster-pool-ipv4-cidr: "10.0.0.0/8"
+  cluster-pool-ipv4-mask-size: "24"
+  disable-cnp-status-updates: "true"
 ---
-# Source: cilium/charts/agent/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
-
----
-# Source: cilium/charts/operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-operator
-  namespace: kube-system
-
----
-# Source: cilium/charts/agent/templates/clusterrole.yaml
+# Source: cilium/templates/cilium-agent-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -159,6 +148,14 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list
@@ -178,6 +175,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -192,40 +199,44 @@ rules:
   verbs:
   - patch
 - apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  # Deprecated for removal in v1.10
   - create
-  - get
   - list
   - watch
   - update
+
+  # This is used when validating policies in preflight. This will need to stay
+  # until we figure out how to avoid "get" inside the preflight, and then
+  # should be removed ideally.
+  - get
 - apiGroups:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumnetworkpolicies/finalizers
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumendpoints
   - ciliumendpoints/status
+  - ciliumendpoints/finalizers
   - ciliumnodes
   - ciliumnodes/status
+  - ciliumnodes/finalizers
   - ciliumidentities
-  - ciliumidentities/status
+  - ciliumidentities/finalizers
+  - ciliumlocalredirectpolicies
+  - ciliumlocalredirectpolicies/status
+  - ciliumlocalredirectpolicies/finalizers
   verbs:
   - '*'
-
 ---
-# Source: cilium/charts/operator/templates/clusterrole.yaml
+# Source: cilium/templates/cilium-operator-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -243,12 +254,16 @@ rules:
   - watch
   - delete
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
-  # to automatically read from k8s and import the node's pod CIDR to cilium's
-  # etcd so all nodes know how to reach another pod running in in a different
-  # node.
-  - nodes
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
@@ -263,17 +278,53 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumnetworkpolicies/finalizers
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumendpoints
   - ciliumendpoints/status
+  - ciliumendpoints/finalizers
   - ciliumnodes
   - ciliumnodes/status
+  - ciliumnodes/finalizers
   - ciliumidentities
   - ciliumidentities/status
+  - ciliumidentities/finalizers
+  - ciliumlocalredirectpolicies
+  - ciliumlocalredirectpolicies/status
+  - ciliumlocalredirectpolicies/finalizers
   verbs:
   - '*'
-
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
-# Source: cilium/charts/agent/templates/clusterrolebinding.yaml
+# Source: cilium/templates/cilium-agent-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -286,9 +337,8 @@ subjects:
 - kind: ServiceAccount
   name: cilium
   namespace: kube-system
-
 ---
-# Source: cilium/charts/operator/templates/clusterrolebinding.yaml
+# Source: cilium/templates/cilium-operator-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -301,22 +351,23 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
-
 ---
-# Source: cilium/charts/agent/templates/daemonset.yaml
+# Source: cilium/templates/cilium-agent-daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
     k8s-app: cilium
-    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: cilium
-      kubernetes.io/cluster-service: "true"
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -325,16 +376,55 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - cilium
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent
+        livenessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -372,43 +462,19 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "{{ .ImageRepository }}/cilium:v1.6.4"
+        image: quay.io/cilium/cilium:v1.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
             exec:
               command:
-              - /cni-install.sh
+              - "/cni-install.sh"
+              - "--enable-debug=false"
           preStop:
             exec:
               command:
               - /cni-uninstall.sh
-        livenessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
-          failureThreshold: 10
-          # The initial delay for the liveness probe is intentionally large to
-          # avoid an endless kill & restart cycle if in the event that the initial
-          # bootstrapping takes longer than expected.
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 5
         name: cilium-agent
-        readinessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:
@@ -459,7 +525,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "{{ .ImageRepository }}/cilium:v1.6.4"
+        image: quay.io/cilium/cilium:v1.9.0
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -470,9 +536,15 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
+          mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
       restartPolicy: Always
+      priorityClassName: system-node-critical
       serviceAccount: cilium
       serviceAccountName: cilium
       terminationGracePeriodSeconds: 1
@@ -518,13 +590,8 @@ spec:
       - configMap:
           name: cilium-config
         name: cilium-config-path
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 2
-    type: RollingUpdate
-
 ---
-# Source: cilium/charts/operator/templates/deployment.yaml
+# Source: cilium/templates/cilium-operator-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -534,7 +601,10 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  replicas: 1
+  # We support HA mode only for Kubernetes version > 1.14
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+  replicas: 2
   selector:
     matchLabels:
       io.cilium/app: operator
@@ -551,114 +621,66 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
-        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
         command:
-        - cilium-operator
+        - cilium-operator-generic
         env:
-        - name: CILIUM_K8S_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
         - name: K8S_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: CILIUM_DEBUG
           valueFrom:
             configMapKeyRef:
               key: debug
               name: cilium-config
               optional: true
-        - name: CILIUM_CLUSTER_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: cluster-name
-              name: cilium-config
-              optional: true
-        - name: CILIUM_CLUSTER_ID
-          valueFrom:
-            configMapKeyRef:
-              key: cluster-id
-              name: cilium-config
-              optional: true
-        - name: CILIUM_IPAM
-          valueFrom:
-            configMapKeyRef:
-              key: ipam
-              name: cilium-config
-              optional: true
-        - name: CILIUM_DISABLE_ENDPOINT_CRD
-          valueFrom:
-            configMapKeyRef:
-              key: disable-endpoint-crd
-              name: cilium-config
-              optional: true
-        - name: CILIUM_KVSTORE
-          valueFrom:
-            configMapKeyRef:
-              key: kvstore
-              name: cilium-config
-              optional: true
-        - name: CILIUM_KVSTORE_OPT
-          valueFrom:
-            configMapKeyRef:
-              key: kvstore-opt
-              name: cilium-config
-              optional: true
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: AWS_ACCESS_KEY_ID
-              name: cilium-aws
-              optional: true
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: AWS_SECRET_ACCESS_KEY
-              name: cilium-aws
-              optional: true
-        - name: AWS_DEFAULT_REGION
-          valueFrom:
-            secretKeyRef:
-              key: AWS_DEFAULT_REGION
-              name: cilium-aws
-              optional: true
-        - name: CILIUM_IDENTITY_ALLOCATION_MODE
-          valueFrom:
-            configMapKeyRef:
-              key: identity-allocation-mode
-              name: cilium-config
-              optional: true
-        image: "{{ .ImageRepository }}/cilium-operator:v1.6.4"
+        image: quay.io/cilium/operator-generic:v1.9.0
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:
           httpGet:
+            host: '127.0.0.1'
             path: /healthz
             port: 9234
             scheme: HTTP
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
-
+        volumeMounts:
+        - mountPath: /tmp/cilium/config-map
+          name: cilium-config-path
+          readOnly: true
       hostNetwork: true
       restartPolicy: Always
+      priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
-
----
-# Source: cilium/charts/agent/templates/servicemonitor.yaml
-
----
-# Source: cilium/charts/agent/templates/svc.yaml
-
----
-# Source: cilium/charts/operator/templates/servicemonitor.yaml
-
----
-# Source: cilium/charts/operator/templates/svc.yaml
+      tolerations:
+      - operator: Exists
+      volumes:
+        # To read the configuration from the config map
+      - configMap:
+          name: cilium-config
+        name: cilium-config-path


### PR DESCRIPTION
Please note:

1. the images for Cilium are taken from quay.io/cilium/ (oficial repo)
2. the operator is run in HA config (replicas count = 1). It leads to failing one of replicas
   in single master mode

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #122
| License         | Apache 2.0

### To Do
- [ ] Put images in banzaicloud repo
- [ ] Make different configurations for cilium-operator (rc=1 for single-master, and rc=2 for other setups)
- [ ] Make extensive tests

