### PR TITLE
Add custom certificate bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /pke-single-config.yaml
 /pke-multi-config.yaml
 
+/crt/*.crt
+
 **/.vagrant*
 .DS_Store
 

--- a/Vagrantfile-centos8
+++ b/Vagrantfile-centos8
@@ -11,6 +11,7 @@ Vagrant.configure("2") do |config|
     # sync build folder
     config.vm.synced_folder '.', '/vagrant', disabled: true
     config.vm.synced_folder 'scripts/vagrant/', '/scripts/', create: true
+    config.vm.synced_folder 'crt/', '/opt/crt/', create: true
     config.vm.synced_folder 'build/', '/banzaicloud/', create: true
 
     $num_instances = 4
@@ -60,6 +61,12 @@ Vagrant.configure("2") do |config|
 
             node.vm.provision "shell" do |s|
                 s.inline = <<-SHELL
+                yum install -y ca-certificates
+                update-ca-trust enable
+                cd /opt/crt
+                find . -type f -name '*.crt' -execdir cp {} /etc/pki/ca-trust/source/anchors/{} \\;
+                update-ca-trust extract
+
                 dnf install -y yum-utils wget curl chrony vim net-tools socat
                 echo 'sync time'
                 systemctl enable --now chronyd


### PR DESCRIPTION
Signed-off-by: George Gaál <gb12335@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add's possibility of using custom certificate bundle for Centos 8 - can be useful for working behind corporate proxy with MitM

### Why?
Because without it the Vagrant will fail during packages installation phase.

### To Do
- [ ] add the analogical feature to Centos7, ubuntu.
