### PR TITLE
fix(cilium): disable kube-proxy-replacement

### DIFF
--- a/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.go
@@ -140,7 +140,7 @@ func ciliumTemplate() string {
 		"  auto-direct-node-routes: \"false\"\n" +
 		"  enable-bandwidth-manager: \"false\"\n" +
 		"  enable-local-redirect-policy: \"false\"\n" +
-		"  kube-proxy-replacement:  \"probe\"\n" +
+		"  kube-proxy-replacement:  \"disabled\"\n" +
 		"  kube-proxy-replacement-healthz-bind-address: \"\"\n" +
 		"  enable-health-check-nodeport: \"true\"\n" +
 		"  node-port-bind-protection: \"true\"\n" +

--- a/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/cilium.yaml.tmpl
@@ -122,7 +122,7 @@ data:
   auto-direct-node-routes: "false"
   enable-bandwidth-manager: "false"
   enable-local-redirect-policy: "false"
-  kube-proxy-replacement:  "probe"
+  kube-proxy-replacement:  "disabled"
   kube-proxy-replacement-healthz-bind-address: ""
   enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Set kube-proxy-replacement to disabled in the cilium config.

### Why?
In the case of the kernel version is 5.x, kube-poxy-replacement will be set and istio will fail.
