### PR TITLE
Replace trigger github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Trigger pke-image build
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.TRIGGER_GH_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'banzaicloud',


### PR DESCRIPTION
Previously used GITHUB_TOKEN is generated by the workflow for one-time use, and only has access to pke repo. That's been replaced by a PAT of banzaicloud-build user.