### PR TITLE
Fixed auto-approver and cilium

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.go
@@ -19,14 +19,23 @@ func certificateAutoApproverTemplate() string {
 	var tmpl = "apiVersion: v1\n" +
 		"kind: ServiceAccount\n" +
 		"metadata:\n" +
-		"  name: kubelet-csr-approver\n" +
+		"  name: auto-approver\n" +
 		"  namespace: kube-system\n" +
 		"---\n" +
 		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRole\n" +
 		"metadata:\n" +
-		"  name: kubelet-csr-approver\n" +
+		"  name: auto-approver\n" +
 		"rules:\n" +
+		"- apiGroups:\n" +
+		"  - certificates.k8s.io\n" +
+		"  resources:\n" +
+		"  - signers\n" +
+		"  resourceNames:\n" +
+		"  - \"kubernetes.io/legacy-unknown\"\n" +
+		"  - \"kubernetes.io/kubelet-serving\"\n" +
+		"  verbs:\n" +
+		"  - approve\n" +
 		"- apiGroups:\n" +
 		"  - certificates.k8s.io\n" +
 		"  resources:\n" +
@@ -40,82 +49,64 @@ func certificateAutoApproverTemplate() string {
 		"  resources:\n" +
 		"  - certificatesigningrequests/approval\n" +
 		"  verbs:\n" +
+		"  - create\n" +
 		"  - update\n" +
 		"- apiGroups:\n" +
-		"  - certificates.k8s.io\n" +
-		"  resourceNames:\n" +
-		"  - kubernetes.io/kubelet-serving\n" +
+		"  - authorization.k8s.io\n" +
 		"  resources:\n" +
-		"  - signers\n" +
+		"  - subjectaccessreviews\n" +
 		"  verbs:\n" +
-		"  - approve\n" +
+		"  - create\n" +
 		"---\n" +
-		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"kind: ClusterRoleBinding\n" +
+		"apiVersion: rbac.authorization.k8s.io/v1\n" +
 		"metadata:\n" +
-		"  name: kubelet-csr-approver\n" +
-		"  namespace: kube-system\n" +
-		"roleRef:\n" +
-		"  apiGroup: rbac.authorization.k8s.io\n" +
-		"  kind: ClusterRole\n" +
-		"  name: kubelet-csr-approver\n" +
+		"  name: auto-approver\n" +
 		"subjects:\n" +
 		"- kind: ServiceAccount\n" +
-		"  name: kubelet-csr-approver\n" +
 		"  namespace: kube-system\n" +
+		"  name: auto-approver\n" +
+		"roleRef:\n" +
+		"  kind: ClusterRole\n" +
+		"  name: auto-approver\n" +
+		"  apiGroup: rbac.authorization.k8s.io\n" +
 		"---\n" +
 		"apiVersion: apps/v1\n" +
 		"kind: Deployment\n" +
 		"metadata:\n" +
-		"  name: kubelet-csr-approver\n" +
+		"  name: auto-approver\n" +
 		"  namespace: kube-system\n" +
 		"spec:\n" +
+		"  replicas: 1\n" +
 		"  selector:\n" +
 		"    matchLabels:\n" +
-		"      app: kubelet-csr-approver\n" +
+		"      name: auto-approver\n" +
 		"  template:\n" +
 		"    metadata:\n" +
-		"      annotations:\n" +
-		"        prometheus.io/port: '8080'\n" +
-		"        prometheus.io/scrape: 'true'\n" +
 		"      labels:\n" +
-		"        app: kubelet-csr-approver\n" +
+		"        name: auto-approver\n" +
 		"    spec:\n" +
-		"      serviceAccountName: kubelet-csr-approver\n" +
-		"      priorityClassName: system-cluster-critical\n" +
-		"      containers:\n" +
-		"        - name: kubelet-csr-approver\n" +
-		"          {{ if ne .ImageRepository \"\" }}\n" +
-		"          image: \"{{ .ImageRepository }}/kubelet-csr-approver:v0.1.3\"\n" +
-		"          {{ else }}\n" +
-		"          image: \"ghcr.io/banzaicloud/kubelet-csr-approver:v0.1.3\"\n" +
-		"          {{ end }}\n" +
-		"          resources:\n" +
-		"            limits:\n" +
-		"              memory: \"128Mi\"\n" +
-		"              cpu: \"500m\"\n" +
-		"          args:\n" +
-		"            - -metrics-bind-address\n" +
-		"            - \":8080\"\n" +
-		"            - -health-probe-bind-address\n" +
-		"            - \":8081\"\n" +
-		"          livenessProbe:\n" +
-		"            httpGet:\n" +
-		"              path: /healthz\n" +
-		"              port: 8081\n" +
-		"          env:\n" +
-		"            - name: PROVIDER_REGEX\n" +
-		"              value: \\w*\n" +
-		"            - name: MAX_EXPIRATION_SECONDS\n" +
-		"              value: '31622400' # 366 days\n" +
-		"            - name: BYPASS_DNS_RESOLUTION\n" +
-		"              value: 'true'\n" +
+		"      serviceAccountName: auto-approver\n" +
 		"      tolerations:\n" +
 		"        - effect: NoSchedule\n" +
-		"          key: node-role.kubernetes.io/master\n" +
-		"          operator: Equal\n" +
-		"        - effect: NoSchedule\n" +
-		"          key: node-role.kubernetes.io/control-plane\n" +
-		"          operator: Equal"
+		"          operator: Exists\n" +
+		"      nodeSelector:\n" +
+		"        node-role.kubernetes.io/master: \"\"\n" +
+		"      priorityClassName: system-cluster-critical\n" +
+		"      containers:\n" +
+		"        - name: auto-approver\n" +
+		"          image: ghcr.io/banzaicloud/auto-approver:0.2.0\n" +
+		"          args:\n" +
+		"            - \"--v=2\"\n" +
+		"          imagePullPolicy: Always\n" +
+		"          env:\n" +
+		"            - name: WATCH_NAMESPACE\n" +
+		"              value: \"\"\n" +
+		"            - name: POD_NAME\n" +
+		"              valueFrom:\n" +
+		"                fieldRef:\n" +
+		"                  fieldPath: metadata.name\n" +
+		"            - name: OPERATOR_NAME\n" +
+		"              value: \"auto-approver\"\n"
 	return tmpl
 }

--- a/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.tmpl
+++ b/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.tmpl
@@ -1,14 +1,23 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubelet-csr-approver
+  name: auto-approver
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubelet-csr-approver
+  name: auto-approver
 rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - "kubernetes.io/legacy-unknown"
+  - "kubernetes.io/kubelet-serving"
+  verbs:
+  - approve
 - apiGroups:
   - certificates.k8s.io
   resources:
@@ -22,80 +31,62 @@ rules:
   resources:
   - certificatesigningrequests/approval
   verbs:
+  - create
   - update
 - apiGroups:
-  - certificates.k8s.io
-  resourceNames:
-  - kubernetes.io/kubelet-serving
+  - authorization.k8s.io
   resources:
-  - signers
+  - subjectaccessreviews
   verbs:
-  - approve
+  - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubelet-csr-approver
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubelet-csr-approver
+  name: auto-approver
 subjects:
 - kind: ServiceAccount
-  name: kubelet-csr-approver
   namespace: kube-system
+  name: auto-approver
+roleRef:
+  kind: ClusterRole
+  name: auto-approver
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kubelet-csr-approver
+  name: auto-approver
   namespace: kube-system
 spec:
+  replicas: 1
   selector:
     matchLabels:
-      app: kubelet-csr-approver
+      name: auto-approver
   template:
     metadata:
-      annotations:
-        prometheus.io/port: '8080'
-        prometheus.io/scrape: 'true'
       labels:
-        app: kubelet-csr-approver
+        name: auto-approver
     spec:
-      serviceAccountName: kubelet-csr-approver
-      priorityClassName: system-cluster-critical
-      containers:
-        - name: kubelet-csr-approver
-          {{ if ne .ImageRepository "" }}
-          image: "{{ .ImageRepository }}/kubelet-csr-approver:v0.1.3"
-          {{ else }}
-          image: "ghcr.io/banzaicloud/kubelet-csr-approver:v0.1.3"
-          {{ end }}
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
-          args:
-            - -metrics-bind-address
-            - ":8080"
-            - -health-probe-bind-address
-            - ":8081"
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
-          env:
-            - name: PROVIDER_REGEX
-              value: \w*
-            - name: MAX_EXPIRATION_SECONDS
-              value: '31622400' # 366 days
-            - name: BYPASS_DNS_RESOLUTION
-              value: 'true'
+      serviceAccountName: auto-approver
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Equal
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
-          operator: Equal
+          operator: Exists
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: auto-approver
+          image: ghcr.io/banzaicloud/auto-approver:0.2.0
+          args:
+            - "--v=2"
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "auto-approver"

--- a/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/controlplane.go
@@ -504,7 +504,7 @@ func (c *ControlPlane) Run(out io.Writer) error {
 			single = true
 		}
 		// TODO get cilium version from flag
-		version := "v1.11.1"
+		version := "v1.9.1"
 		if err := installCilium(out, kubeConfig, c.podNetworkCIDR, c.imageRepository, version, c.mtu, single); err != nil {
 			return err
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Use banzaicloud/auto-approver instead of banzaicloud/kubelet-csr-approver for auto-approving CSRs.

Downgraded Cilium 1.11.1 -> 1.9.1.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

There were issues with the certificates in the latest PKE 0.9.x release.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~