### PR TITLE
update cri and containerd and add node-name flag to init

### DIFF
--- a/cmd/pke/app/constants/constants.go
+++ b/cmd/pke/app/constants/constants.go
@@ -103,6 +103,9 @@ const (
 	// FlagClusterName cluster name
 	FlagClusterName = "kubernetes-cluster-name"
 
+	// FlagNodeName nodename for init
+	FlagNodeName = "kubernetes-node-name"
+
 	// FlagOIDCIssuerURL OIDC issuer URL
 	FlagOIDCIssuerURL = "kubernetes-oidc-issuer-url"
 	// FlagOIDCClientID OIDC client ID

--- a/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/certificate_auto_approver.yaml.go
@@ -107,6 +107,6 @@ func certificateAutoApproverTemplate() string {
 		"                fieldRef:\n" +
 		"                  fieldPath: metadata.name\n" +
 		"            - name: OPERATOR_NAME\n" +
-		"              value: \"auto-approver\"\n"
+		"              value: \"auto-approver\""
 	return tmpl
 }

--- a/cmd/pke/app/phases/kubeadm/controlplane/controlplane_test.go
+++ b/cmd/pke/app/phases/kubeadm/controlplane/controlplane_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/stretchr/testify/require"
+
+	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 )
 
 func TestWriteKubeadmConfig(t *testing.T) {

--- a/cmd/pke/app/phases/kubeadm/node/kubeadm.go
+++ b/cmd/pke/app/phases/kubeadm/node/kubeadm.go
@@ -22,11 +22,12 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/Masterminds/semver"
+	"github.com/pbnjay/memory"
+
 	"github.com/banzaicloud/pke/cmd/pke/app/phases/kubeadm"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/cri"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/kubernetes"
-	"github.com/pbnjay/memory"
 )
 
 //go:generate templify -t ${GOTMPL} -p node -f kubeadmConfigV1Beta2 kubeadm_v1beta2.yaml.tmpl

--- a/cmd/pke/app/phases/pipeline/ready/ready.go
+++ b/cmd/pke/app/phases/pipeline/ready/ready.go
@@ -23,14 +23,15 @@ import (
 	"os"
 
 	"emperror.dev/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/banzaicloud/pke/.gen/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
 	"github.com/banzaicloud/pke/cmd/pke/app/phases"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/network"
 	pipelineutil "github.com/banzaicloud/pke/cmd/pke/app/util/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/validator"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const (

--- a/cmd/pke/app/phases/runtime/container/containerd_linux.go
+++ b/cmd/pke/app/phases/runtime/container/containerd_linux.go
@@ -23,13 +23,14 @@ import (
 	"text/template"
 
 	"emperror.dev/errors"
+
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/linux"
 )
 
 const (
-	containerdVersion     = "1.5.9"
-	containerdSHA256      = "f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488"
+	containerdVersion     = "1.6.8"
+	containerdSHA256      = "8e227caa318faa136e4387ffd6f96baeaad5582d176202fe9da69cde87036033"
 	containerdURL         = "https://github.com/containerd/containerd/releases/download/v%s/cri-containerd-cni-%s-linux-amd64.tar.gz"
 	containerdVersionPath = "/opt/containerd/cluster/version"
 	containerdConf        = "/etc/containerd/config.toml"
@@ -108,8 +109,8 @@ func installContainerd(out io.Writer, imageRepository string) error {
 		return errors.Wrapf(err, "unable to create temporary file: %q", f.Name())
 	}
 	defer func() { _ = f.Close() }()
-	// export CONTAINERD_VERSION="1.5.9"
-	// export CONTAINERD_SHA256="f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488"
+	// export CONTAINERD_VERSION="1.6.8"
+	// export CONTAINERD_SHA256="8e227caa318faa136e4387ffd6f96baeaad5582d176202fe9da69cde87036033"
 	// wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
 	dl := fmt.Sprintf(containerdURL, containerdVersion, containerdVersion)
 	u, err := url.Parse(dl)

--- a/cmd/pke/app/util/linux/apt.go
+++ b/cmd/pke/app/util/linux/apt.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
+
 	"github.com/banzaicloud/pke/cmd/pke/app/util/file"
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 )
@@ -140,7 +141,7 @@ func mapAptPackageVersion(pkg, kubernetesVersion string) string {
 		return "kubelet=" + getAptPackageVersion(kubernetesVersion)
 
 	case kubernetescni:
-		return "kubernetes-cni=0.8.7-00"
+		return "kubernetes-cni=1.1.1-00"
 
 	default:
 		return ""

--- a/cmd/pke/app/util/linux/rpm.go
+++ b/cmd/pke/app/util/linux/rpm.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
+
 	"github.com/banzaicloud/pke/cmd/pke/app/util/runner"
 )
 
@@ -28,7 +29,7 @@ const (
 	kubectl                   = "kubectl"
 	kubelet                   = "kubelet"
 	kubernetescni             = "kubernetes-cni"
-	kubernetesCNIVersion      = "0.8.7"
+	kubernetesCNIVersion      = "1.1.1"
 	disableExcludesKubernetes = "--disableexcludes=kubernetes"
 	selinuxConfig             = "/etc/selinux/config"
 )

--- a/cmd/pke/app/util/pipeline/status.go
+++ b/cmd/pke/app/util/pipeline/status.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/banzaicloud/pke/.gen/pipeline"
 	"github.com/banzaicloud/pke/cmd/pke/app/constants"
-	"github.com/spf13/cobra"
 )
 
 type pipelineStatusReporter struct {


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
- update cri and containerd
- add --node-name flag for kubeadm init